### PR TITLE
fix(search): body-bearing tools always use JSON, not detected per-query

### DIFF
--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -2366,13 +2366,23 @@ def _handle_call_uncached(name, arguments):
             return "missing required 'kql'", True
         since = arguments.get("since") or "15m ago"
         warning = ""
+        wide_projection = False
         if KQL_VALIDATION_MODE != "off":
             report = _validate_user_kql(str(kql), since)
             if _blocking_validation(report):
                 return _format_validation_rejection(report), True
             if KQL_VALIDATION_MODE == "warn":
                 warning = _format_validation_warnings(report)
-        out, err = bzrk_search(str(kql), since)
+            wide_projection = any(
+                f.get("code") == "WIDE_PROJECTION"
+                for f in report.get("findings", [])
+            )
+        # Switch to JSON mode when body/$raw columns are projected so the full
+        # content is returned instead of being truncated by table alignment.
+        if wide_projection:
+            out, err = bzrk_search_json(str(kql), since)
+        else:
+            out, err = bzrk_search(str(kql), since)
         if warning and not err:
             return warning + "\n\n" + out, False
         return out, err

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -1231,13 +1231,17 @@ def bzrk_search(kql, since, extra=None):
 # output. Both known clap phrasings put the literal word "argument"
 # immediately next to the (usually quoted) flag it's rejecting -- "unexpected
 # argument '--json' found" / "Found argument '--json' which wasn't
-# expected" -- so anchoring on "argument '--json'" is both narrower and more
-# reliable than matching on rejection-word vocabulary. A prior version tried
-# to match on words like "invalid" appearing anywhere near "--json", which
-# also matched unrelated runtime errors that merely mention the flag in
-# passing (e.g. "backend returned invalid JSON while processing --json
-# request"), silently masking the real failure as an unsupported-flag case.
-_JSON_UNSUPPORTED_RE = re.compile(r"(?i)argument\s*['\"]?--json['\"]?")
+# expected" -- so anchoring on "argument '--json'" is narrower and more
+# reliable than matching on rejection-word vocabulary (a prior version
+# matched words like "invalid" appearing anywhere near "--json", which also
+# matched unrelated runtime errors merely mentioning the flag in passing).
+# "argument '--json'" alone can still coincidentally appear in an unrelated
+# message, so this additionally requires clap's own usage/help trailer,
+# which every real clap argument-parse error appends and a genuinely
+# unrelated backend/serialization error won't happen to also produce.
+_JSON_UNSUPPORTED_RE = re.compile(
+    r"(?i)argument\s*['\"]?--json['\"]?(?=.*?(usage:|--help))", re.DOTALL
+)
 
 
 def bzrk_search_json(kql, since):

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -851,6 +851,47 @@ def q_find_similar(description, service=None, k=10):
     )
 
 
+# Legacy fallback only: pre-existing bzrk builds that reject --json return
+# plain table text from bzrk_search_json's fallback, where a `_score` column
+# renders as a single line ("_score   0.83") immediately adjacent to its
+# value -- unlike --json's Tables/schema/rows shape, where the column name
+# and its value are never textually adjacent (see _find_similar_has_real_score).
+_FIND_SIMILAR_SCORE_TABLE_RE = re.compile(
+    r"_score\s+(-?[1-9]\d*(?:\.\d+)?|0?\.\d*[1-9]\d*)"
+)
+
+
+def _find_similar_has_real_score(out):
+    """True if a genuinely non-zero `_score` value is present. bzrk's real
+    --json output is the Kusto-style {"Tables": [{"schema": {"columns":
+    [...]}, "rows": [[...]]}]} shape (confirmed live 2026-07-17, see
+    agent_analytics._json_records) -- rows are positional arrays zipped
+    against column order, so the column name "_score" and its value are
+    never textually adjacent and can't be found by pattern-matching the raw
+    text. Reuses the same column/row-zip helper agent_analytics already
+    validates against real output, rather than re-parsing it here. Falls
+    back to the table-adjacency regex only when `out` isn't parseable JSON
+    at all, i.e. bzrk_search_json degraded to its legacy table fallback."""
+    whole = str(out or "").strip()
+    if not whole or whole[0] not in "[{":
+        return bool(_FIND_SIMILAR_SCORE_TABLE_RE.search(out))
+    try:
+        records = agent_analytics._json_records(json.loads(whole))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return bool(_FIND_SIMILAR_SCORE_TABLE_RE.search(out))
+    if records is None:
+        return bool(_FIND_SIMILAR_SCORE_TABLE_RE.search(out))
+    for row in records:
+        if not isinstance(row, dict) or "_score" not in row:
+            continue
+        try:
+            if float(row["_score"]) != 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 def _forecast_fit_rows(text):
     """Extract native ``series_fit_line`` coefficients from bzrk JSON.
 
@@ -1185,18 +1226,18 @@ def bzrk_search(kql, since, extra=None):
     return out, is_err
 
 
-# bzrk builds that don't support --json reject it with an argument-parse error;
-# detect that so we can transparently fall back to the default table output.
-# Requires an actual rejection word AND the literal --json token on the same
-# line, in either order (clap phrases this both ways across versions) -- a
-# bare `--json` substring match is too broad and can misclassify an unrelated
-# runtime error (e.g. a backend failure that happens to mention the flag) as
-# an unsupported-flag case, silently masking the real failure.
-_JSON_UNSUPPORTED_RE = re.compile(
-    r"(?i)(unrecognized|unexpected|unknown|invalid|wasn't expected|isn't expected)"
-    r"[^\n]*?--json"
-    r"|--json[^\n]*?(unrecognized|unexpected|unknown|invalid|wasn't expected|isn't expected)"
-)
+# bzrk builds that don't support --json reject it with an argument-parse
+# error; detect that so we can transparently fall back to the default table
+# output. Both known clap phrasings put the literal word "argument"
+# immediately next to the (usually quoted) flag it's rejecting -- "unexpected
+# argument '--json' found" / "Found argument '--json' which wasn't
+# expected" -- so anchoring on "argument '--json'" is both narrower and more
+# reliable than matching on rejection-word vocabulary. A prior version tried
+# to match on words like "invalid" appearing anywhere near "--json", which
+# also matched unrelated runtime errors that merely mention the flag in
+# passing (e.g. "backend returned invalid JSON while processing --json
+# request"), silently masking the real failure as an unsupported-flag case.
+_JSON_UNSUPPORTED_RE = re.compile(r"(?i)argument\s*['\"]?--json['\"]?")
 
 
 def bzrk_search_json(kql, since):
@@ -1674,13 +1715,20 @@ SIMPLE = {
     "trace_find_errors": (Q_TRACE_FIND_ERRORS, "1h ago"),
 }
 
-# SIMPLE tools whose fixed query includes a `body` column, even though it's
-# already substring-capped at the KQL level (200-500 chars). Confirmed
+# SIMPLE tools whose fixed query derives output from `body`, even though
+# it's already substring-capped at the KQL level (200-500 chars). Confirmed
 # empirically that the runtime table renderer can still clip those capped
 # values further depending on the calling process's terminal-width detection
-# -- unrelated to the KQL-level cap. The rest of SIMPLE is aggregation-only
-# and never carries body content, so it stays on the more compact table mode.
-_SIMPLE_JSON_TOOLS = {"claude_errors", "soc_high_severity_logs"}
+# -- unrelated to the KQL-level cap. sre_top_error_messages and
+# soc_repeated_errors derive their `example` column from
+# substring(tostring(body), ...) rather than projecting a literal `body`
+# column, which is easy to miss on a quick scan. The rest of SIMPLE is
+# aggregation-only and never carries body-derived content, so it stays on
+# the more compact table mode.
+_SIMPLE_JSON_TOOLS = {
+    "claude_errors", "soc_high_severity_logs",
+    "sre_top_error_messages", "soc_repeated_errors",
+}
 
 _QUERY_RISK_BUDGET_MULTIPLIERS = {
     "low": 1.0,
@@ -2284,10 +2332,7 @@ def _handle_call_uncached(name, arguments):
                     "search with has '<term>' for exact terms.", False
                 )
             return out, True
-        # Matches a real score in either table cell ("_score   0.83") or JSON
-        # field ("_score": 0.83) shape -- the quote/colon between the key and
-        # value are both optional so either rendering satisfies it.
-        if "_score" in out and not re.search(r'_score["\']?\s*:?\s*(-?[1-9]\d*(?:\.\d+)?|0?\.\d*[1-9]\d*)', out):
+        if "_score" in out and not _find_similar_has_real_score(out):
             return (
                 "Semantic indexing is not enabled on this Berserk cluster — falling "
                 "back is not possible for meaning-based search; use search with "

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -1187,8 +1187,15 @@ def bzrk_search(kql, since, extra=None):
 
 # bzrk builds that don't support --json reject it with an argument-parse error;
 # detect that so we can transparently fall back to the default table output.
+# Requires an actual rejection word AND the literal --json token on the same
+# line, in either order (clap phrases this both ways across versions) -- a
+# bare `--json` substring match is too broad and can misclassify an unrelated
+# runtime error (e.g. a backend failure that happens to mention the flag) as
+# an unsupported-flag case, silently masking the real failure.
 _JSON_UNSUPPORTED_RE = re.compile(
-    r"(?i)(unrecognized|unexpected|unknown|invalid)\b.*\b(argument|option|flag|--?json)|--json"
+    r"(?i)(unrecognized|unexpected|unknown|invalid|wasn't expected|isn't expected)"
+    r"[^\n]*?--json"
+    r"|--json[^\n]*?(unrecognized|unexpected|unknown|invalid|wasn't expected|isn't expected)"
 )
 
 
@@ -1667,6 +1674,14 @@ SIMPLE = {
     "trace_find_errors": (Q_TRACE_FIND_ERRORS, "1h ago"),
 }
 
+# SIMPLE tools whose fixed query includes a `body` column, even though it's
+# already substring-capped at the KQL level (200-500 chars). Confirmed
+# empirically that the runtime table renderer can still clip those capped
+# values further depending on the calling process's terminal-width detection
+# -- unrelated to the KQL-level cap. The rest of SIMPLE is aggregation-only
+# and never carries body content, so it stays on the more compact table mode.
+_SIMPLE_JSON_TOOLS = {"claude_errors", "soc_high_severity_logs"}
+
 _QUERY_RISK_BUDGET_MULTIPLIERS = {
     "low": 1.0,
     "medium": 1.5,
@@ -1980,7 +1995,7 @@ def _handle_call_uncached(name, arguments):
                 )
             if _blocking_validation(report):
                 return prefix + _format_validation_rejection(report), True
-        out, err = bzrk_search(match["kql"], since)
+        out, err = bzrk_search_json(match["kql"], since)
         return prefix + out, err
     if name == "save_query":
         nm = sanitize_name(arguments.get("name", ""))
@@ -1994,7 +2009,7 @@ def _handle_call_uncached(name, arguments):
             validation_report = _validate_user_kql(kql, since)
             if _blocking_validation(validation_report, persistence=True):
                 return _format_validation_rejection(validation_report), True
-        out, is_err = bzrk_search(kql, since)
+        out, is_err = bzrk_search_json(kql, since)
         if is_err:
             return "NOT saved - the query failed when verified:\n" + out, True
         all_items = load_learned()
@@ -2260,7 +2275,7 @@ def _handle_call_uncached(name, arguments):
         except (TypeError, ValueError):
             return "k must be an integer between 1 and 50", True
         since = arguments.get("since") or "6h ago"
-        out, err = bzrk_search(q_find_similar(description, service or None, k), since)
+        out, err = bzrk_search_json(q_find_similar(description, service or None, k), since)
         if err:
             if "similarto" in str(out).lower() or "semantic" in str(out).lower():
                 return (
@@ -2269,7 +2284,10 @@ def _handle_call_uncached(name, arguments):
                     "search with has '<term>' for exact terms.", False
                 )
             return out, True
-        if "_score" in out and not re.search(r"_score\s+(-?[1-9]\d*(?:\.\d+)?|0?\.\d*[1-9]\d*)", out):
+        # Matches a real score in either table cell ("_score   0.83") or JSON
+        # field ("_score": 0.83) shape -- the quote/colon between the key and
+        # value are both optional so either rendering satisfies it.
+        if "_score" in out and not re.search(r'_score["\']?\s*:?\s*(-?[1-9]\d*(?:\.\d+)?|0?\.\d*[1-9]\d*)', out):
             return (
                 "Semantic indexing is not enabled on this Berserk cluster — falling "
                 "back is not possible for meaning-based search; use search with "
@@ -2281,6 +2299,8 @@ def _handle_call_uncached(name, arguments):
     if name in SIMPLE:
         kql, default_since = SIMPLE[name]
         since = arguments.get("since") or default_since
+        if name in _SIMPLE_JSON_TOOLS:
+            return bzrk_search_json(kql, since)
         return bzrk_search(kql, since)
 
     if name == "soc_new_services":
@@ -2328,7 +2348,7 @@ def _handle_call_uncached(name, arguments):
         if not _valid_interpolated_name(svc):
             return "invalid service name (allowed: letters, digits, '.', '_', '-')", True
         since = arguments.get("since") or "1h ago"
-        return bzrk_search(q_logs(str(svc)), since)
+        return bzrk_search_json(q_logs(str(svc)), since)
     if name == "sre_service_health":
         svc = arguments.get("service")
         if not svc:
@@ -2344,7 +2364,7 @@ def _handle_call_uncached(name, arguments):
         if not _valid_interpolated_name(svc):
             return "invalid service name (allowed: letters, digits, '.', '_', '-')", True
         since = arguments.get("since") or "6h ago"
-        return bzrk_search(q_soc_timeline(str(svc)), since)
+        return bzrk_search_json(q_soc_timeline(str(svc)), since)
     if name == "trace_analyze":
         trace_id = arguments.get("trace_id")
         if not trace_id:
@@ -2358,7 +2378,7 @@ def _handle_call_uncached(name, arguments):
         # any logs sharing the same trace_id — treated as a failure only if
         # BOTH halves fail, since a trace can legitimately have no logs.
         out1, e1 = bzrk_search(q_trace_analyze(str(trace_id)), "30d ago")
-        out2, e2 = bzrk_search(q_trace_logs(str(trace_id)), "30d ago")
+        out2, e2 = bzrk_search_json(q_trace_logs(str(trace_id)), "30d ago")
         return f"== spans ==\n{out1}\n\n== correlated logs ==\n{out2}", (e1 and e2)
     if name == "search":
         kql = arguments.get("kql")
@@ -2366,23 +2386,20 @@ def _handle_call_uncached(name, arguments):
             return "missing required 'kql'", True
         since = arguments.get("since") or "15m ago"
         warning = ""
-        wide_projection = False
         if KQL_VALIDATION_MODE != "off":
             report = _validate_user_kql(str(kql), since)
             if _blocking_validation(report):
                 return _format_validation_rejection(report), True
             if KQL_VALIDATION_MODE == "warn":
                 warning = _format_validation_warnings(report)
-            wide_projection = any(
-                f.get("code") == "WIDE_PROJECTION"
-                for f in report.get("findings", [])
-            )
-        # Switch to JSON mode when body/$raw columns are projected so the full
-        # content is returned instead of being truncated by table alignment.
-        if wide_projection:
-            out, err = bzrk_search_json(str(kql), since)
-        else:
-            out, err = bzrk_search(str(kql), since)
+        # Always JSON: whether table-mode clips a wide `body`/`$raw` column
+        # depends on the calling process's terminal-width detection, not on
+        # anything visible in the KQL text -- confirmed empirically (see PR
+        # description) that identical queries clip under the real deployment
+        # path but not in a local interactive shell. Static detection from
+        # the query shape can't be trusted either direction, so arbitrary
+        # user KQL always gets full-fidelity output.
+        out, err = bzrk_search_json(str(kql), since)
         if warning and not err:
             return warning + "\n\n" + out, False
         return out, err
@@ -2395,7 +2412,7 @@ def _handle_call_uncached(name, arguments):
         if _TEXT_GUARD_RE.search(str(term)):
             return "term may not contain quotes, pipe, backslash, or backtick", True
         since = arguments.get("since") or "6h ago"
-        return bzrk_search(q_cc_search(str(term)), since)
+        return bzrk_search_json(q_cc_search(str(term)), since)
     if name == "claude_loop_check":
         since = arguments.get("since") or "6h ago"
         if not valid_since(since):

--- a/tests/test_agent_analytics.py
+++ b/tests/test_agent_analytics.py
@@ -421,7 +421,12 @@ class BzrkSearchJsonTest(unittest.TestCase):
         def fake(args, timeout=bm.DEFAULT_TIMEOUT):
             seen.append(list(args))
             if "--json" in args:
-                return ("error: unexpected argument '--json' found", True)
+                return (
+                    "error: unexpected argument '--json' found\n\n"
+                    "Usage: bzrk search [OPTIONS] <QUERY>\n\n"
+                    "For more information, try '--help'.",
+                    True,
+                )
             return ("table out", False)
 
         bm.run_bzrk = fake

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -3695,6 +3695,20 @@ class BodyPreservingJsonModeTest(unittest.TestCase):
         self.assertFalse(err, text)
         self.assertIn("--json", self.calls[-1])
 
+    def test_sre_top_error_messages_simple_dispatch_uses_json(self):
+        # Q_SRE_TOP_ERRORS derives its `example` column from body via
+        # substring(min(tostring(body)), 0, 240) -- same shape as the other
+        # body-bearing SIMPLE tools, just easy to miss since "body" never
+        # appears as a bare column name.
+        text, err = bm.handle_call("sre_top_error_messages", {})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_soc_repeated_errors_simple_dispatch_uses_json(self):
+        text, err = bm.handle_call("soc_repeated_errors", {})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
     def test_trace_analyze_spans_table_logs_json(self):
         text, err = bm.handle_call("trace_analyze", {"trace_id": "abc123"})
         self.assertFalse(err, text)
@@ -3716,9 +3730,24 @@ class BodyPreservingJsonModeTest(unittest.TestCase):
         self.assertIn("--json", self.calls[-1])
 
     def test_find_similar_detects_real_score_in_json_shape(self):
+        # bzrk's actual --json output (see agent_analytics._json_records and
+        # its docstring, confirmed live 2026-07-17) is a Kusto-style
+        # {"Tables": [{"schema": {"columns": [...]}, "rows": [[...]]}]}
+        # shape -- rows are positional arrays, not row objects, so the
+        # column name "_score" and its value are never textually adjacent.
+        # A regex that assumes {"_score": value} inline objects can't parse
+        # this correctly; the real fix reuses agent_analytics._parse_rows,
+        # which already zips columns against rows.
+        doc = {
+            "Tables": [{
+                "schema": {"columns": [{"name": "body"}, {"name": "_score"}]},
+                "rows": [["match text", 0.834521]],
+            }]
+        }
+
         def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
             self.calls.append(list(args))
-            return ('[{"_score": 0.834521, "body": "x"}]', False)
+            return (json.dumps(doc), False)
 
         bm.run_bzrk = fake_run_bzrk
         text, err = bm.handle_call("find_similar", {"description": "timeouts"})
@@ -3743,9 +3772,36 @@ class BodyPreservingJsonModeTest(unittest.TestCase):
         self.assertNotIn("Semantic indexing is not enabled", text)
 
     def test_find_similar_falls_back_when_no_real_score_present(self):
+        doc = {
+            "Tables": [{
+                "schema": {"columns": [{"name": "body"}, {"name": "_score"}]},
+                "rows": [["no real ranking", 0]],
+            }]
+        }
+
         def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
             self.calls.append(list(args))
-            return ('[{"_score": 0, "body": "x"}]', False)
+            return (json.dumps(doc), False)
+
+        bm.run_bzrk = fake_run_bzrk
+        text, err = bm.handle_call("find_similar", {"description": "timeouts"})
+        self.assertFalse(err, text)
+        self.assertIn("Semantic indexing is not enabled", text)
+
+    def test_find_similar_does_not_match_score_mentioned_only_in_body_text(self):
+        # Regression for the exact false-positive Codex's review demonstrated:
+        # a body value that happens to contain the substring "_score" must
+        # never be read as a real ranking score.
+        doc = {
+            "Tables": [{
+                "schema": {"columns": [{"name": "body"}, {"name": "_score"}]},
+                "rows": [["upstream payload mentions _score: 1 in its text", 0]],
+            }]
+        }
+
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return (json.dumps(doc), False)
 
         bm.run_bzrk = fake_run_bzrk
         text, err = bm.handle_call("find_similar", {"description": "timeouts"})
@@ -3773,6 +3829,16 @@ class JsonUnsupportedFallbackTest(unittest.TestCase):
     def test_unrelated_error_without_json_does_not_trigger_fallback(self):
         self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
             "error: invalid value for '--profile'"
+        ))
+
+    def test_invalid_json_response_error_does_not_trigger_fallback(self):
+        # A rejection word ("invalid") and "--json" can both appear in an
+        # unrelated message without either referring to an unsupported CLI
+        # flag -- here "invalid" describes the backend's JSON response, and
+        # "--json" is just naming the request flag that was used, not being
+        # rejected. Must not be misread as an unsupported-flag error.
+        self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
+            "backend returned invalid JSON while processing --json request"
         ))
 
 

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -374,7 +374,11 @@ class BerserkMcpTest(unittest.TestCase):
         text, err = bm.handle_call("run_saved", {"name": "big_errors"})
         self.assertFalse(err)
         self.assertEqual(self.calls[-1][3], "default | where severity_text=='ERROR' | count")
-        self.assertEqual(self.calls[-1][-1], "1d ago")
+        self.assertEqual(self.calls[-1][5], "1d ago")
+        # run_saved must use the same fidelity as search/save_query -- a
+        # replayed query can't silently drop to a lower-fidelity mode than
+        # the one that verified it before persisting.
+        self.assertIn("--json", self.calls[-1])
 
     def test_save_not_persisted_when_query_fails(self):
         def failing(args, timeout=bm.DEFAULT_TIMEOUT):
@@ -3601,6 +3605,175 @@ class CanonLoomTest(unittest.TestCase):
         text, err = bm.handle_call("canonloom_get_artifact", {})
         self.assertTrue(err)
         self.assertIn("artifact_id", text.lower())
+
+
+class BodyPreservingJsonModeTest(unittest.TestCase):
+    """Table-mode output can silently clip wide `body` columns depending on
+    the runtime's terminal-width detection (confirmed empirically against a
+    live cluster: identical 3-4 column queries truncated over the deployed
+    MCP path but not via a local interactive shell -- the earlier
+    WIDE_PROJECTION static-KQL-detection approach could never predict this,
+    since it depends on the calling environment, not the query text). Every
+    dispatch path that can surface `body` content to a caller must use
+    bzrk_search_json unconditionally rather than guessing from KQL shape."""
+
+    def setUp(self):
+        self.calls = []
+
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return ("OK", False)
+
+        self._orig = bm.run_bzrk
+        bm.run_bzrk = fake_run_bzrk
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig_learned = bm.LEARNED_PATH
+        bm.LEARNED_PATH = Path(self._tmp.name) / "learned.json"
+
+    def tearDown(self):
+        bm.run_bzrk = self._orig
+        bm.LEARNED_PATH = self._orig_learned
+        self._tmp.cleanup()
+
+    def test_search_always_uses_json_regardless_of_projection_shape(self):
+        # A narrow, non-body-projecting query used to stay on table mode
+        # under the old WIDE_PROJECTION-detection design. It must not
+        # anymore -- the truncation risk is environment-driven, not
+        # KQL-shape-driven, so detection from the query text can't be
+        # trusted either way.
+        narrow_kql = f"{bm.TABLE} | summarize count() by resource['service.name']"
+        text, err = bm.handle_call("search", {"kql": narrow_kql})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+        wide_kql = f"{bm.TABLE} | project timestamp, body | take 5"
+        self.calls.clear()
+        text, err = bm.handle_call("search", {"kql": wide_kql})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_run_saved_uses_json(self):
+        bm.handle_call("save_query", {
+            "name": "wide_probe", "description": "d",
+            "kql": f"{bm.TABLE} | project timestamp, body | take 5",
+        })
+        self.calls.clear()
+        text, err = bm.handle_call("run_saved", {"name": "wide_probe"})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_save_query_verify_call_uses_json(self):
+        self.calls.clear()
+        bm.handle_call("save_query", {
+            "name": "verify_probe", "description": "d",
+            "kql": f"{bm.TABLE} | project timestamp, body | take 5",
+        })
+        self.assertIn("--json", self.calls[-1])
+
+    def test_logs_for_service_uses_json(self):
+        text, err = bm.handle_call("logs_for_service", {"service": "api"})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_soc_timeline_uses_json(self):
+        text, err = bm.handle_call("soc_timeline", {"service": "api"})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_claude_search_uses_json(self):
+        text, err = bm.handle_call("claude_search", {"term": "timeout"})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_claude_errors_simple_dispatch_uses_json(self):
+        text, err = bm.handle_call("claude_errors", {})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_soc_high_severity_logs_simple_dispatch_uses_json(self):
+        text, err = bm.handle_call("soc_high_severity_logs", {})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_trace_analyze_spans_table_logs_json(self):
+        text, err = bm.handle_call("trace_analyze", {"trace_id": "abc123"})
+        self.assertFalse(err, text)
+        spans_argv, logs_argv = self.calls[-2], self.calls[-1]
+        self.assertNotIn("--json", spans_argv)
+        self.assertIn("--json", logs_argv)
+
+    def test_non_body_simple_tool_stays_on_table_mode(self):
+        """Negative control: aggregation-only SIMPLE tools never carry body
+        content by construction, so they should stay compact rather than
+        being blanket-converted along with the body-bearing ones."""
+        text, err = bm.handle_call("top_cpu", {})
+        self.assertFalse(err, text)
+        self.assertNotIn("--json", self.calls[-1])
+
+    def test_find_similar_uses_json(self):
+        text, err = bm.handle_call("find_similar", {"description": "timeouts"})
+        self.assertFalse(err, text)
+        self.assertIn("--json", self.calls[-1])
+
+    def test_find_similar_detects_real_score_in_json_shape(self):
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return ('[{"_score": 0.834521, "body": "x"}]', False)
+
+        bm.run_bzrk = fake_run_bzrk
+        text, err = bm.handle_call("find_similar", {"description": "timeouts"})
+        self.assertFalse(err, text)
+        self.assertNotIn("Semantic indexing is not enabled", text)
+
+    def test_find_similar_detects_real_score_in_table_shape(self):
+        # Legacy fallback path only (old bzrk builds without --json support):
+        # single-line "_score" immediately adjacent to its value, matching
+        # what the pre-existing regex was already written to detect -- a
+        # genuine multi-row table with the header ("_score:double") and the
+        # value on separate lines was never something either regex handled,
+        # and isn't this test's concern; it only guards against regressing
+        # the adjacency case the original code already covered.
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return ("_score       0.834521   body_text_here", False)
+
+        bm.run_bzrk = fake_run_bzrk
+        text, err = bm.handle_call("find_similar", {"description": "timeouts"})
+        self.assertFalse(err, text)
+        self.assertNotIn("Semantic indexing is not enabled", text)
+
+    def test_find_similar_falls_back_when_no_real_score_present(self):
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return ('[{"_score": 0, "body": "x"}]', False)
+
+        bm.run_bzrk = fake_run_bzrk
+        text, err = bm.handle_call("find_similar", {"description": "timeouts"})
+        self.assertFalse(err, text)
+        self.assertIn("Semantic indexing is not enabled", text)
+
+
+class JsonUnsupportedFallbackTest(unittest.TestCase):
+    def test_clap_style_unexpected_argument_triggers_fallback(self):
+        self.assertTrue(bm._JSON_UNSUPPORTED_RE.search(
+            "error: unexpected argument '--json' found\n\nUsage: bzrk search [OPTIONS] <QUERY>"
+        ))
+
+    def test_reversed_clap_style_found_argument_triggers_fallback(self):
+        # Older clap builds phrase the same rejection in the opposite order.
+        self.assertTrue(bm._JSON_UNSUPPORTED_RE.search(
+            "Found argument '--json' which wasn't expected, or isn't valid in this context"
+        ))
+
+    def test_unrelated_error_mentioning_json_does_not_trigger_fallback(self):
+        self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
+            "backend unavailable while processing --json request"
+        ))
+
+    def test_unrelated_error_without_json_does_not_trigger_fallback(self):
+        self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
+            "error: invalid value for '--profile'"
+        ))
 
 
 class SinceNormalizerTest(unittest.TestCase):

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -3754,22 +3754,30 @@ class BodyPreservingJsonModeTest(unittest.TestCase):
         self.assertFalse(err, text)
         self.assertNotIn("Semantic indexing is not enabled", text)
 
-    def test_find_similar_detects_real_score_in_table_shape(self):
-        # Legacy fallback path only (old bzrk builds without --json support):
-        # single-line "_score" immediately adjacent to its value, matching
-        # what the pre-existing regex was already written to detect -- a
-        # genuine multi-row table with the header ("_score:double") and the
-        # value on separate lines was never something either regex handled,
-        # and isn't this test's concern; it only guards against regressing
-        # the adjacency case the original code already covered.
+    def test_find_similar_table_fallback_is_conservative_not_a_false_positive(self):
+        # Legacy fallback only (old bzrk builds without --json support): a
+        # genuine multi-row ASCII table separates the column header
+        # ("_score:double") from its value (on a later row, under that
+        # column's position), so there's no reliable single-line adjacency
+        # to pattern-match -- unlike --json's Tables/schema/rows shape,
+        # which is parsed structurally and doesn't have this ambiguity.
+        # Rather than guess and risk a false positive (claiming semantic
+        # search works when it may not), any non-JSON output that mentions
+        # "_score" at all is treated as inconclusive and reported as
+        # "not enabled", matching the tool's existing conservative posture
+        # for every other ambiguous case (see the `err` branch above).
         def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
             self.calls.append(list(args))
-            return ("_score       0.834521   body_text_here", False)
+            return (
+                " #   _score:double        body:string\n"
+                " 0   0.834521             match_text",
+                False,
+            )
 
         bm.run_bzrk = fake_run_bzrk
         text, err = bm.handle_call("find_similar", {"description": "timeouts"})
         self.assertFalse(err, text)
-        self.assertNotIn("Semantic indexing is not enabled", text)
+        self.assertIn("Semantic indexing is not enabled", text)
 
     def test_find_similar_falls_back_when_no_real_score_present(self):
         doc = {
@@ -3816,9 +3824,11 @@ class JsonUnsupportedFallbackTest(unittest.TestCase):
         ))
 
     def test_reversed_clap_style_found_argument_triggers_fallback(self):
-        # Older clap builds phrase the same rejection in the opposite order.
+        # Older clap builds phrase the same rejection in the opposite order,
+        # and (like all clap argument errors) append a usage/help trailer.
         self.assertTrue(bm._JSON_UNSUPPORTED_RE.search(
-            "Found argument '--json' which wasn't expected, or isn't valid in this context"
+            "Found argument '--json' which wasn't expected, or isn't valid "
+            "in this context\n\nFor more information, try '--help'."
         ))
 
     def test_unrelated_error_mentioning_json_does_not_trigger_fallback(self):
@@ -3839,6 +3849,16 @@ class JsonUnsupportedFallbackTest(unittest.TestCase):
         # rejected. Must not be misread as an unsupported-flag error.
         self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
             "backend returned invalid JSON while processing --json request"
+        ))
+
+    def test_unrelated_error_incidentally_containing_argument_json_does_not_trigger_fallback(self):
+        # A message can coincidentally contain the literal substring
+        # "argument '--json'" without being clap's own argument-parser
+        # rejection -- real clap errors always append their own usage/help
+        # trailer, which a genuinely unrelated backend error won't happen
+        # to also produce.
+        self.assertFalse(bm._JSON_UNSUPPORTED_RE.search(
+            "backend returned invalid JSON while processing argument '--json'"
         ))
 
 


### PR DESCRIPTION
## Summary

Originally: switch the `search` tool to `--json` mode when a static KQL validator finding (`WIDE_PROJECTION`) detected `body`/`$raw` in the projection, since table-mode output can truncate wide columns.

That went through **three rounds of Codex review** (see PR comments for full detail on each). Net result after all three:

- **Static KQL detection is gone entirely.** Confirmed empirically that truncation isn't query-shape-dependent — it's the calling process's terminal-width detection. An identical query clipped over the real MCP dispatch path but not run interactively via `bzrk` CLI directly, even against KQL that already applies a 200–500 char `substring()` cap. No KQL-text check could predict that either way.
- **Every dispatch path that can surface `body` content now always uses `bzrk_search_json`**, unconditionally: `search`, `run_saved`, `save_query`'s verify call, `find_similar`, `logs_for_service`, `soc_timeline`, `trace_analyze`'s correlated-logs half, `claude_search`, and four body-derived `SIMPLE`-dispatched tools (`claude_errors`, `soc_high_severity_logs`, `sre_top_error_messages`, `soc_repeated_errors`) via a `_SIMPLE_JSON_TOOLS` allowlist. Aggregation-only tools stay on table mode — covered by a negative-control test.
- **`find_similar`'s `_score` detection rewritten** to reuse `agent_analytics._json_records`, the same column/row-zip parser already validated against bzrk's real `Tables/schema/rows` `--json` shape elsewhere in this file, instead of pattern-matching raw text (which assumed an inline `{"_score": value}` shape that doesn't match reality, and could both false-positive on `_score` mentioned inside body text and false-negative on genuinely working results).
- **`_JSON_UNSUPPORTED_RE` rewritten twice**: first to require an actual rejection phrase near `--json` (fixing a bare-substring match that misrouted unrelated errors into the table fallback), then tightened further to also require clap's own usage/help trailer, since "argument '--json'" alone could still coincidentally appear in an unrelated message.

## What this trades off

JSON responses carry more metadata per row than table format. For high-row-count tools (`logs_for_service` `| tail 50`, `claude_search` `| tail 40`), this is a real payload increase, not free. Correctness (no silent data loss) was judged to outweigh the extra verbosity; a future pass narrowing the JSON payload to just the requested columns would reduce that cost.

## Evidence

- Tests assert **dispatch wiring** (`--json` present/absent in captured argv) and **parsing correctness** against realistic bzrk output shapes — they don't re-prove that truncation is real, which was verified empirically as described above (depends on runtime terminal-width detection outside this process, not something a unit test can cover).
- `python tests/test_berserk_mcp.py` — 283 tests, all pass
- `python -m unittest discover -s tests` — 636 tests, all pass (1 pre-existing unrelated skip)
- `python evals/mcp_protocol_smoke.py --include-http` — all pass
- Written test-first throughout (TDD): every new/changed test confirmed failing for the expected reason before the corresponding implementation change, across all three review rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)