### PR TITLE
feat(doctor): --doctor preflight, self_check tool, full .env.example coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,224 @@
 # berserk-mcp example configuration
 #
-# Safe default: do not set any of these unless you need the optional HTTP
-# transport. berserk-mcp uses stdio by default and opens no network listener.
+# Safe default: nothing here needs to be set. berserk-mcp uses stdio and the
+# built-in query/budget/redaction defaults out of the box; every var below is
+# an opt-in override. Grouped by concern; run `berserk-mcp --doctor` (or call
+# the `self_check` tool) to verify your actual configuration is coherent.
+
+# ---------------------------------------------------------------------------
+# Core: bzrk CLI and the table being queried
+# ---------------------------------------------------------------------------
+
+# Path/name of the bzrk binary. Default: "bzrk" (resolved on PATH). Set to an
+# absolute path if bzrk isn't on PATH, or to pin a specific build.
+# BZRK_BIN=bzrk
+
+# bzrk profile to query (see `bzrk profile list`). Default: "local".
+# BZRK_PROFILE=local
+
+# Per-query timeout in seconds. Default: 120.
+# BZRK_TIMEOUT=120
+
+# The Berserk table to query. Default: "default".
+# BERSERK_TABLE=default
+
+# ---------------------------------------------------------------------------
+# Server behavior: budgets, caching, concurrency
+# ---------------------------------------------------------------------------
+
+# Max random startup delay for `--worker` (cron/systemd), in seconds. Spreads
+# load when many berserk-mcp workers start on the same schedule. Default: 7200.
+# BERSERK_WORKER_JITTER_SECONDS=7200
+
+# Interactive tools/call timeout budget in seconds. Default: 10.
+# BERSERK_MCP_TOOL_BUDGET_SECONDS=10
+
+# Extra per-hour-of-window budget added on top of BERSERK_MCP_TOOL_BUDGET_SECONDS,
+# scaled by query risk multiplier -- wider windows earn more time. Default: 0.5.
+# BERSERK_MCP_BUDGET_PER_HOUR_SECONDS=0.5
+
+# How long an identical failing call is suppressed (returns the cached
+# failure instead of re-running), in seconds. Default: 30.
+# BERSERK_MCP_FAIL_COOLDOWN_SECONDS=30
+
+# Read-only result cache TTL in seconds. Default: 120.
+# BERSERK_MCP_CACHE_TTL_SECONDS=120
+
+# Max in-process query concurrency. Default: 2.
+# BERSERK_MCP_MAX_CONCURRENT_QUERIES=2
+
+# Hard cap on captured bzrk stdout, in bytes. Default: 10485760 (10 MiB).
+# BERSERK_MCP_MAX_RESULT_BYTES=10485760
+
+# ---------------------------------------------------------------------------
+# KQL validation
+# ---------------------------------------------------------------------------
+
+# Validation policy for user-authored KQL: off/warn/strict. Default: "warn".
+# BERSERK_MCP_KQL_VALIDATION=warn
+
+# Allow validate_kql mode=live (executes a bounded read-only query). Default:
+# disabled ("0").
+# BERSERK_MCP_KQL_LIVE_VALIDATION=0
+
+# Maximum user KQL length in characters. Default: 50000.
+# BERSERK_MCP_KQL_MAX_CHARS=50000
+
+# Recommended row bound for arbitrary queries (advisory, not enforced).
+# Default: 2000.
+# BERSERK_MCP_KQL_MAX_ROWS=2000
+
+# Stats handling for live-validated/executed queries: off/auto/required.
+# Default: "auto".
+# BERSERK_MCP_KQL_STATS=auto
+
+# ---------------------------------------------------------------------------
+# Role, primers, and saved-query storage
+# ---------------------------------------------------------------------------
+
+# Active role lane, filters which tools are advertised: all/sre/soc/claude/
+# ops/windows-forensics. Default: "all".
+# BERSERK_MCP_ROLE=all
+
+# Directory containing <role>.md primer files, overriding the built-in ones
+# shipped next to this script. Must be an absolute, existing directory.
+# BERSERK_MCP_PRIMERS_DIR=
+
+# Where saved queries (save_query/run_saved) persist. Default: per-user
+# config dir (e.g. ~/.config/berserk-mcp/learned.json, or %APPDATA% on
+# Windows).
+# BERSERK_MCP_LEARNED_PATH=
+
+# ---------------------------------------------------------------------------
+# Output redaction / privacy
+# ---------------------------------------------------------------------------
+
+# Secret/PII redaction mode for tool output: off/flag/redact. Default:
+# "redact" (the safest setting; an invalid value also fails closed to this).
+# BERSERK_MCP_REDACT=redact
+
+# Also redact high-entropy strings (likely tokens/keys) in tool output.
+# Default: disabled.
+# BERSERK_MCP_REDACT_ENTROPY=0
+
+# Comma-separated PII type names to redact in tool output (see
+# secret_scan.ALL_PII_TYPES for the recognized set). Default: none.
+# BERSERK_MCP_REDACT_PII=
+
+# Also redact high-entropy strings specifically in AI FinOps free-text
+# fields. Default: disabled.
+# BERSERK_MCP_FINOPS_REDACT_ENTROPY=0
+
+# Deployment-scoped HMAC key used to pseudonymize identifiers in AI FinOps
+# exports. Default: derived from local machine state if unset. Set this to
+# get stable pseudonyms across redeployments, or to share them across a fleet.
+# BERSERK_MCP_PSEUDONYM_KEY=
+
+# ---------------------------------------------------------------------------
+# Claude Code agent analytics
+# ---------------------------------------------------------------------------
+
+# OTLP attribute name carrying input token counts. Default:
+# "claude.tokens_input".
+# BERSERK_MCP_TOKENS_IN_ATTR=claude.tokens_input
+
+# OTLP attribute name carrying output token counts. Default:
+# "claude.tokens_output".
+# BERSERK_MCP_TOKENS_OUT_ATTR=claude.tokens_output
+
+# Comma-separated directory names used to infer a project root when
+# attributing sessions to projects. Default: "src,tests,lib,pkg".
+# BERSERK_MCP_PROJECT_MARKERS=src,tests,lib,pkg
+
+# Path to a JSON catalog of known/expected ingestion sources, used by
+# detect_new_sources / suggest_ingestion. Default: none configured.
+# BERSERK_MCP_INGESTION_CATALOG=
+
+# Max newly-detected sources auto-queued for parser generation per
+# --worker pass. Default: 5.
+# BERSERK_MAX_AUTOQUEUE=5
+
+# ---------------------------------------------------------------------------
+# Parser factory: LLM-driven parser generation (parser_factory.py)
+# ---------------------------------------------------------------------------
+# All optional -- a provider with no key configured is skipped. Adds
+# outbound HTTP to whichever LLM providers you configure.
+
+# Provider order for generation. Default: "hermes,openai,anthropic".
+# BERSERK_LLM_LADDER=hermes,openai,anthropic
+
+# Bearer token for the Hermes endpoint.
+# HERMES_API_KEY=
+
+# Hermes chat-completions endpoint. Default: local llm_config.json if set via
+# `berserk-mcp --set-hermes-url <URL>`, else http://localhost:3000/api/chat/completions.
+# BERSERK_LLM_HERMES_URL=
+
+# Hermes model id. Default: auto-discovered via Hermes's /api/models.
+# BERSERK_LLM_HERMES_MODEL=
+
+# Allow a plaintext (non-https) Hermes URL on a non-loopback host. Default:
+# disabled -- plaintext credentials never cross the network unencrypted
+# without this explicit opt-in. Only set this on a trusted private network.
+# BERSERK_LLM_ALLOW_PLAINTEXT_REMOTE=0
+
+# OpenAI API key.
+# OPENAI_API_KEY=
+
+# OpenAI model. Default: "gpt-4o".
+# BERSERK_LLM_OPENAI_MODEL=gpt-4o
+
+# Anthropic API key.
+# ANTHROPIC_API_KEY=
+
+# Anthropic model. Default: "claude-opus-4-8".
+# BERSERK_LLM_ANTHROPIC_MODEL=claude-opus-4-8
+
+# Per-LLM-call timeout in seconds. Default: 120.
+# BERSERK_LLM_TIMEOUT=120
+
+# Max wall-clock seconds for one parser-generation job's full refinement
+# loop. Default: 300.
+# BERSERK_LLM_JOB_DEADLINE_SECONDS=300
+
+# ---------------------------------------------------------------------------
+# CanonLoom knowledge-artifact lifecycle bridge (optional, separate service)
+# ---------------------------------------------------------------------------
+
+# CanonLoom server base URL. Required for the canonloom_* tools; unset means
+# those tools return a clear "not configured" error instead of failing.
+# Example: http://localhost:8080
+# CANONLOOM_SERVER_URL=
+
+# Bearer/API key for the CanonLoom server, if it requires one.
+# CANONLOOM_API_KEY=
+
+# ---------------------------------------------------------------------------
+# Discord alert bridge (optional, --worker only)
+# ---------------------------------------------------------------------------
+
+# Shared secret for the local Discord alert bridge. Unset disables alerting
+# entirely -- it's opt-in, never required.
+# BERSERK_DISCORD_ALERT_SECRET=
+
+# Discord alert bridge URL. Default: http://127.0.0.1:8765/alert.
+# BERSERK_DISCORD_ALERT_URL=http://127.0.0.1:8765/alert
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry forwarding (optional; used by claude_* analytics tooling)
+# ---------------------------------------------------------------------------
+# BERSERK_MCP_OTLP_* takes priority; the bare OTEL_EXPORTER_OTLP_* names are
+# read as a fallback for compatibility with standard OTel SDK configuration.
+
+# BERSERK_MCP_OTLP_LOGS_ENDPOINT=
+# BERSERK_MCP_OTLP_HEADERS=
+# OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=
+# OTEL_EXPORTER_OTLP_HEADERS=
+
+# ---------------------------------------------------------------------------
+# HTTP transport (optional; berserk-mcp uses stdio by default)
+# ---------------------------------------------------------------------------
+# Leave this whole section commented for Claude Desktop/Claude Code stdio use.
 
 # Enable the optional HTTP transport.
 # Default: disabled by default. Leave commented for Claude Desktop/Claude Code stdio use.
@@ -55,7 +272,28 @@
 # Loopback reverse proxy example:
 # BERSERK_MCP_HTTP_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
 
+# ---------------------------------------------------------------------------
+# Protocol gate
+# ---------------------------------------------------------------------------
+
 # Enable gated MCP 2026-07-28 compatibility features.
 # Default: disabled. Leave commented unless the client supports this newer MCP
 # mode and you have tested compatibility.
 # BERSERK_MCP_ENABLE_2026_07_28=1
+
+# ---------------------------------------------------------------------------
+# Standard OS variables read as config-dir fallbacks (not berserk-mcp-
+# specific -- listed here only so `--doctor`'s drift guard has full coverage
+# of every env var this codebase reads)
+# ---------------------------------------------------------------------------
+
+# Windows: base dir for the default learned-query/pseudonym-key location
+# (%APPDATA%\berserk-mcp\...). Sourced from Windows itself; you shouldn't
+# need to set this specifically for berserk-mcp.
+# APPDATA=
+
+# Non-Windows: base dir for the default learned-query/pseudonym-key location
+# ($XDG_CONFIG_HOME/berserk-mcp/..., falling back to ~/.config). Standard
+# XDG Base Directory variable; you shouldn't need to set this specifically
+# for berserk-mcp.
+# XDG_CONFIG_HOME=

--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,22 @@
 # get stable pseudonyms across redeployments, or to share them across a fleet.
 # BERSERK_MCP_PSEUDONYM_KEY=
 
+# Where AI FinOps business-catalog data persists. Default: alongside the
+# learned-query store (see BERSERK_MCP_LEARNED_PATH).
+# BERSERK_MCP_BUSINESS_STORE_PATH=
+
+# Where AI FinOps optimization recommendations persist. Default: alongside
+# the learned-query store.
+# BERSERK_MCP_RECOMMENDATION_STORE_PATH=
+
+# Directory AI FinOps writes generated reports into. Default: alongside the
+# learned-query store.
+# BERSERK_MCP_REPORT_DIR=
+
+# Path to the AI FinOps pricing catalog. Default: pricing_catalog.json next
+# to this script.
+# BERSERK_MCP_PRICING_CATALOG_PATH=
+
 # ---------------------------------------------------------------------------
 # Claude Code agent analytics
 # ---------------------------------------------------------------------------

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -3712,6 +3712,33 @@ def _serve_http():
 _DOCTOR_REACHABILITY_TIMEOUT = 5
 
 
+def _with_wall_clock_timeout(fn, timeout):
+    """Run fn() with a genuine wall-clock deadline. urllib's own timeout=
+    only bounds individual socket connect/read operations, not total time
+    -- a server that sends the next byte just inside that window on every
+    read can keep a request open far longer than the advertised timeout
+    implies (measured: 8.02s wall clock against a 5s per-operation
+    timeout). Returns None if fn() hasn't finished within `timeout`
+    seconds. A plain daemon thread, not concurrent.futures.ThreadPoolExecutor:
+    the executor registers an atexit hook that joins pending work, which
+    would make the whole process hang waiting for exactly the slow call
+    this exists to stop waiting on. The tradeoff this accepts: Python
+    cannot forcibly kill a thread, so a truly stuck call keeps running in
+    the background after this returns -- harmless for a one-shot preflight
+    check, since the daemon thread cannot block process exit either."""
+    box = {}
+
+    def runner():
+        box["result"] = fn()
+
+    t = threading.Thread(target=runner, daemon=True)
+    t.start()
+    t.join(timeout)
+    if t.is_alive():
+        return None
+    return box.get("result")
+
+
 def _doctor_result(name, status, detail, remediation=None, required=True):
     result = {"name": name, "status": status, "detail": detail, "required": required}
     if remediation:
@@ -3743,7 +3770,17 @@ def _doctor_check_bzrk_version():
             "bzrk_version", "fail", str(out)[:200],
             remediation="confirm `bzrk --version` runs from this environment",
         )
-    return _doctor_result("bzrk_version", "pass", str(out).strip())
+    # An exit-zero process that isn't actually bzrk (e.g. BZRK_BIN pointed
+    # at /usr/bin/true, or run_bzrk's own synthetic "(no rows)") must not
+    # satisfy this check just because nothing errored.
+    text = str(out).strip()
+    if not text.lower().startswith("bzrk"):
+        return _doctor_result(
+            "bzrk_version", "fail",
+            f"output does not look like a bzrk version string: {text[:200]!r}",
+            remediation="confirm BZRK_BIN actually points at the Berserk CLI",
+        )
+    return _doctor_result("bzrk_version", "pass", text)
 
 
 def _doctor_check_auth():
@@ -3787,14 +3824,22 @@ def _doctor_check_recent_rows():
     count = None
     try:
         records = agent_analytics._json_records(json.loads(out))
-    except (TypeError, ValueError, json.JSONDecodeError):
+    except (TypeError, ValueError, AttributeError, json.JSONDecodeError):
         records = None
     if records:
         row = records[0]
         if isinstance(row, dict):
             count = row.get("Count", row.get("count"))
+    # This is a required check: a query that "succeeds" without yielding a
+    # real count is not evidence the table is reachable and ingesting --
+    # same failure mode as bzrk_version accepting any exit-zero output.
     if count is None:
-        return _doctor_result("recent_rows", "pass", "query succeeded; row count unavailable from response")
+        return _doctor_result(
+            "recent_rows", "fail",
+            f"query succeeded but no usable Count in the response: {str(out)[:150]!r}",
+            remediation=f"confirm BERSERK_TABLE={TABLE!r} and the bzrk build return the "
+                         "expected --json shape for `| count`",
+        )
     return _doctor_result("recent_rows", "pass", f"{count} row(s) in the last 1h")
 
 
@@ -3837,6 +3882,13 @@ def _doctor_check_primers_dir():
 
 
 def _doctor_check_learned_store_writable():
+    if LEARNED_PATH.is_dir():
+        return _doctor_result(
+            "learned_store_writable", "fail",
+            f"{LEARNED_PATH} already exists as a directory",
+            remediation="BERSERK_MCP_LEARNED_PATH must name a file, not a "
+                         "directory -- the atomic save would fail with IsADirectoryError",
+        )
     parent = LEARNED_PATH.parent
     try:
         parent.mkdir(parents=True, exist_ok=True)
@@ -3885,16 +3937,22 @@ def _doctor_check_http_config():
 
 
 def _doctor_check_llm_reachability():
+    # parser_factory._hermes_url() always resolves to SOME URL -- it falls
+    # back to a hardcoded localhost default when nothing is explicitly
+    # configured, and generation features attempt that default outright.
+    # So "unconfigured" never means "nothing will be attempted"; skipping
+    # in that case would report exit_code=0 while generation would still
+    # fail hitting an unreachable default. Always probe the real effective
+    # URL, staying optional (required=False) so an operator who doesn't use
+    # generation features still isn't pushed to "broken" by it.
     configured = bool(os.environ.get("BERSERK_LLM_HERMES_URL")) or bool(
         parser_factory._llm_config().get("hermes_url")
     )
-    if not configured:
-        return _doctor_result(
-            "llm_hermes_reachability", "skip",
-            "BERSERK_LLM_HERMES_URL not set; generation features are optional",
-            required=False,
-        )
     url = parser_factory._hermes_url()
+    if not configured:
+        url_note = f" (using the unconfigured default {url!r})"
+    else:
+        url_note = ""
     models_url = url.rsplit("/", 3)[0] + "/api/models" if "/api/" in url else None
     if not models_url:
         return _doctor_result(
@@ -3904,14 +3962,30 @@ def _doctor_check_llm_reachability():
         )
     key = os.environ.get("HERMES_API_KEY", "")
     headers = {"Authorization": f"Bearer {key}"} if key else {}
-    _out, err = _http.http_get_json(models_url, headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT)
-    if err:
+    outcome = _with_wall_clock_timeout(
+        lambda: _http.http_get_json(models_url, headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT),
+        _DOCTOR_REACHABILITY_TIMEOUT,
+    )
+    if outcome is None:
         return _doctor_result(
-            "llm_hermes_reachability", "fail", f"unreachable at {models_url}: {err}",
-            remediation="confirm Hermes is running and BERSERK_LLM_HERMES_URL is correct",
+            "llm_hermes_reachability", "fail",
+            f"timed out after {_DOCTOR_REACHABILITY_TIMEOUT}s probing {models_url}{url_note}",
+            remediation="Hermes is not responding in time; confirm it's running and reachable",
             required=False,
         )
-    return _doctor_result("llm_hermes_reachability", "pass", f"reachable at {models_url}", required=False)
+    _out, err = outcome
+    if err:
+        return _doctor_result(
+            "llm_hermes_reachability", "fail", f"unreachable at {models_url}{url_note}: {err}",
+            remediation="confirm Hermes is running and BERSERK_LLM_HERMES_URL is correct"
+                         if configured else
+                         "set BERSERK_LLM_HERMES_URL (or run `berserk-mcp --set-hermes-url`) "
+                         "if you use generation features, or ignore this if you don't",
+            required=False,
+        )
+    return _doctor_result(
+        "llm_hermes_reachability", "pass", f"reachable at {models_url}{url_note}", required=False,
+    )
 
 
 def _doctor_check_canonloom_reachability():
@@ -3926,9 +4000,20 @@ def _doctor_check_canonloom_reachability():
     api_key = os.environ.get("CANONLOOM_API_KEY")
     if api_key:
         headers["X-API-Key"] = api_key
-    _out, err = _http.http_get_json(
-        server_url + "/artifacts", headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT
+    outcome = _with_wall_clock_timeout(
+        lambda: _http.http_get_json(
+            server_url + "/artifacts", headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT
+        ),
+        _DOCTOR_REACHABILITY_TIMEOUT,
     )
+    if outcome is None:
+        return _doctor_result(
+            "canonloom_reachability", "fail",
+            f"timed out after {_DOCTOR_REACHABILITY_TIMEOUT}s probing {server_url}",
+            remediation="CanonLoom is not responding in time; confirm it's running and reachable",
+            required=False,
+        )
+    _out, err = outcome
     if err:
         return _doctor_result(
             "canonloom_reachability", "fail", f"unreachable at {server_url}: {err}",
@@ -3938,22 +4023,55 @@ def _doctor_check_canonloom_reachability():
     return _doctor_result("canonloom_reachability", "pass", f"reachable at {server_url}", required=False)
 
 
+_DOCTOR_CHECK_FUNCS = (
+    ("bzrk_resolvable", _doctor_check_bzrk_resolvable),
+    ("bzrk_version", _doctor_check_bzrk_version),
+    ("auth", _doctor_check_auth),
+    ("table_reachable", _doctor_check_table_reachable),
+    ("recent_rows", _doctor_check_recent_rows),
+    ("primers_dir", _doctor_check_primers_dir),
+    ("learned_store_writable", _doctor_check_learned_store_writable),
+    ("http_config", _doctor_check_http_config),
+    ("llm_hermes_reachability", _doctor_check_llm_reachability),
+    ("canonloom_reachability", _doctor_check_canonloom_reachability),
+)
+
+# table_reachable and recent_rows query the same profile as auth. If auth
+# has already failed, re-running them would just fail the same way for the
+# same reason -- reporting three separate "fail" rows for one root cause
+# is misleading, not more informative. Skip them and point at auth instead.
+_DOCTOR_AUTH_DEPENDENT_CHECKS = frozenset({"table_reachable", "recent_rows"})
+
+
 def _run_doctor_checks():
-    """Ordered preflight checks. Each runs independently -- one failing
-    check does not skip the rest, so a single invocation gives the fullest
-    possible picture in one pass."""
-    return [
-        _doctor_check_bzrk_resolvable(),
-        _doctor_check_bzrk_version(),
-        _doctor_check_auth(),
-        _doctor_check_table_reachable(),
-        _doctor_check_recent_rows(),
-        _doctor_check_primers_dir(),
-        _doctor_check_learned_store_writable(),
-        _doctor_check_http_config(),
-        _doctor_check_llm_reachability(),
-        _doctor_check_canonloom_reachability(),
-    ]
+    """Ordered preflight checks. Each runs independently and is isolated
+    from the others: one check failing does not skip the rest (except the
+    deliberate auth-dependency short-circuit below), and one check raising
+    an unexpected exception produces a failed result for just that check
+    rather than losing the whole report -- a preflight tool must never
+    itself crash."""
+    results = []
+    auth_failed = False
+    for name, fn in _DOCTOR_CHECK_FUNCS:
+        if name in _DOCTOR_AUTH_DEPENDENT_CHECKS and auth_failed:
+            results.append(_doctor_result(
+                name, "skip",
+                "skipped: auth already failed, so this check's own result "
+                "would be uninformative -- see the auth check above",
+            ))
+            continue
+        try:
+            result = fn()
+        except Exception as exc:
+            result = _doctor_result(
+                name, "fail", f"check raised {type(exc).__name__}: {exc}"[:200],
+                remediation="this looks like a bug in berserk-mcp's own "
+                             "doctor check, not your configuration; please report it",
+            )
+        results.append(result)
+        if name == "auth":
+            auth_failed = result["status"] == "fail"
+    return results
 
 
 def _doctor_exit_code(results):
@@ -3980,7 +4098,20 @@ def _format_doctor_table(results):
 def run_doctor(json_output=False):
     """Preflight readiness check. Prints a pass/fail/skip table (or JSON
     with --json) and returns 0/1/2 -- usable as a fleet readiness probe or
-    a container healthcheck, not just interactive output."""
+    a container healthcheck, not just interactive output.
+
+    Cannot help with every misconfiguration: an invalid BZRK_BIN (line
+    ~132) or a BERSERK_MCP_PRIMERS_DIR pointed at a missing primer file
+    (line ~430) both fail the whole process at import time, before main()
+    ever parses --doctor. That's deliberate, predates this function, and
+    isn't something a preflight check run from inside the same process can
+    route around -- weakening either to let --doctor limp past would also
+    weaken the fail-fast guarantee for every other code path that isn't
+    --doctor. Those two cases exit with a direct, specific error message on
+    stderr instead; --doctor covers everything that doesn't already fail
+    that way (see _doctor_check_bzrk_resolvable and _doctor_check_primers_dir
+    for the cases that don't hard-exit -- bzrk simply missing from PATH, or
+    a missing built-in primer with no PRIMERS_DIR override)."""
     results = _run_doctor_checks()
     code = _doctor_exit_code(results)
     if json_output:

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -1782,6 +1782,7 @@ TOOLS = [
     {"name": "list_metrics", "description": "List every metric name currently being ingested, with sample counts + last-seen. Use to DISCOVER what telemetry exists before writing a `search` query.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "bzrk_query_perf", "description": "Berserk query engine latency percentiles: p50, p95, p99 in µs. Use for 'how fast is Berserk?', 'query latency', or 'p50/p95/p99 execution time'. Uses otel_histogram_percentile($raw, N) — the native Berserk histogram aggregate.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "discover_schema", "description": "Discover the shape of a data source: returns (1) every key present under `resource` with row counts, AND (2) a small structural sample with resource/attribute keys and body/metric presence flags. It never exports raw resource, attributes, or body values. Use to learn an unknown or newly-ingested source before querying it. Optional `service` filter. Pair with list_services / list_metrics. Once you work out a query with `search`, persist it with save_query so it becomes reusable.", "inputSchema": {"type": "object", "properties": dict({"service": {"type": "string", "maxLength": MAX_INTERPOLATED_NAME_CHARS, "description": "optional: limit to one service.name"}}, **_since())}},
+    {"name": "self_check", "description": "Preflight readiness report for this berserk-mcp server: bzrk resolvable, bzrk version, auth, table reachable, recent row count, primers dir, learned-store writable, HTTP config coherence, and optional LLM/CanonLoom reachability. Use when a tool call keeps failing and it's unclear whether it's a wiring problem versus genuinely nothing to report. Same checks as `berserk-mcp --doctor`.", "inputSchema": {"type": "object", "properties": {}}},
     {"name": "validate_kql", "roles": ["sre", "soc", "claude", "ops"], "description": "Validate custom Berserk KQL before saving or running it. Static mode does not contact Berserk except for cached schema context; live mode is opt-in, executes a bounded read-only query, and may consume query budget.", "inputSchema": {"type": "object", "properties": dict({"kql": {"type": "string", "description": f"KQL starting with '{TABLE} | ...'."}, "mode": {"type": "string", "enum": ["static", "live"], "default": "static"}, "use_schema": {"type": "boolean", "default": True, "description": "Use cached/discovered schema for unknown-field checks."}}, **_since()), "required": ["kql"]}},
     {"name": "search", "description": "Run an arbitrary Kusto/KQL query against the Berserk table. Use when the other tools do not fit; once it works, persist it with save_query. Fields are nested OTLP resource/log attributes, NOT flat columns — access as resource['service.name'], resource['host.name'], attributes['systemd.unit'], etc. (bare service_name/host_name do not exist and silently match zero rows instead of erroring). If you don't already know the exact field names for this source, call discover_schema first instead of guessing.", "inputSchema": {"type": "object", "properties": dict({"kql": {"type": "string", "description": f"KQL starting with '{TABLE} | ...'. Field access is resource['key'] / attributes['key'], never a bare column name."}}, **_since()), "required": ["kql"]}},
     {"name": "detect_anomalies", "roles": ["sre", "soc"], "description": "Statistical anomaly detection for service event volume over time. Uses zero-filled make-series and series_decompose_anomalies; use for 'is anything behaving abnormally?' rather than guessing a threshold. Optional service filter.", "inputSchema": {"type": "object", "properties": dict({"service": {"type": "string", "maxLength": MAX_INTERPOLATED_NAME_CHARS, "description": "optional service.name filter"}}, **_since())}},
@@ -2376,6 +2377,14 @@ def _handle_call_uncached(name, arguments):
         return "\n".join(filtered), False
 
     # --- tools needing input validation or extra calls ---
+    if name == "self_check":
+        results = _run_doctor_checks()
+        code = _doctor_exit_code(results)
+        # is_err only on "broken" (2) -- a "degraded" report (1, e.g. an
+        # optional integration unreachable) is a successful, informative
+        # call, not a failed one; it shouldn't trip fail-cooldown/retry
+        # handling meant for genuine tool-call failures.
+        return json.dumps({"checks": results, "exit_code": code}, indent=2, sort_keys=True), code == 2
     if name == "schema":
         return do_schema()
     if name == "discover_schema":
@@ -3690,6 +3699,297 @@ def _serve_http():
         server.server_close()
 
 
+# ---------- --doctor / self_check preflight ----------
+# Fleet/air-gapped deployments can't iterate interactively (see F-008's
+# fail-fast comment above, extended here from one env var to the whole
+# config surface): everything from a missing `bzrk` binary to a wrong
+# BZRK_PROFILE to an empty database fails late and opaquely, addressed to
+# an agent rather than an operator. These checks give one ordered,
+# pass/fail/skip readiness report usable as a fleet probe, a container
+# healthcheck, or something an agent hitting repeated errors can call
+# itself to tell "wired wrong" apart from "genuinely nothing to report".
+
+_DOCTOR_REACHABILITY_TIMEOUT = 5
+
+
+def _doctor_result(name, status, detail, remediation=None, required=True):
+    result = {"name": name, "status": status, "detail": detail, "required": required}
+    if remediation:
+        result["remediation"] = remediation
+    return result
+
+
+def _doctor_check_bzrk_resolvable(bzrk_bin_config=None, **resolve_kwargs):
+    config = _BZRK_BIN_CONFIG if bzrk_bin_config is None else bzrk_bin_config
+    try:
+        resolved = _resolve_bzrk_binary(config, **resolve_kwargs)
+    except ValueError as exc:
+        return _doctor_result(
+            "bzrk_resolvable", "fail", f"invalid BZRK_BIN: {exc}",
+            remediation="set BZRK_BIN to an absolute path or a bare executable name",
+        )
+    if resolved is None:
+        return _doctor_result(
+            "bzrk_resolvable", "fail", f"{config!r} not found on PATH",
+            remediation="install the Berserk CLI, or set BZRK_BIN to its absolute path",
+        )
+    return _doctor_result("bzrk_resolvable", "pass", f"resolved to {resolved}")
+
+
+def _doctor_check_bzrk_version():
+    out, err = run_bzrk(["--version"])
+    if err:
+        return _doctor_result(
+            "bzrk_version", "fail", str(out)[:200],
+            remediation="confirm `bzrk --version` runs from this environment",
+        )
+    return _doctor_result("bzrk_version", "pass", str(out).strip())
+
+
+def _doctor_check_auth():
+    out, err = run_bzrk(["-P", PROFILE, "search", f"{TABLE} | take 1", "--since", "15m ago"])
+    if err and str(out) == AUTH_FAILURE_MESSAGE:
+        return _doctor_result(
+            "auth", "fail", "bzrk authentication failed",
+            remediation="run `bzrk login` under profile " + repr(PROFILE),
+        )
+    if err:
+        # A non-auth error here is table_reachable's concern, not auth's --
+        # don't double-report the same failure under two check names.
+        return _doctor_result("auth", "skip", f"could not verify independently of query result: {out}"[:200])
+    return _doctor_result("auth", "pass", f"authenticated under profile {PROFILE!r}")
+
+
+def _doctor_check_table_reachable():
+    out, err = run_bzrk(["-P", PROFILE, "search", f"{TABLE} | take 1", "--since", "15m ago"])
+    if err:
+        return _doctor_result(
+            "table_reachable", "fail", str(out)[:200],
+            remediation=f"confirm BERSERK_TABLE={TABLE!r} exists and profile {PROFILE!r} can query it",
+        )
+    return _doctor_result("table_reachable", "pass", f"{TABLE!r} reachable under profile {PROFILE!r}")
+
+
+def _doctor_check_recent_rows():
+    # --stats' rows_returned counts response rows (always 1 for `| count`'s
+    # single summary row), not the count value itself -- that value only
+    # comes back in the row body, so this needs --json and the real
+    # Tables/schema/rows shape (confirmed live), same parser used elsewhere
+    # in this file for the same reason.
+    out, err = run_bzrk(
+        ["-P", PROFILE, "search", f"{TABLE} | count", "--since", "1h ago", "--json"]
+    )
+    if err:
+        return _doctor_result(
+            "recent_rows", "fail", str(out)[:200],
+            remediation=f"confirm BERSERK_TABLE={TABLE!r} is actively ingesting",
+        )
+    count = None
+    try:
+        records = agent_analytics._json_records(json.loads(out))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        records = None
+    if records:
+        row = records[0]
+        if isinstance(row, dict):
+            count = row.get("Count", row.get("count"))
+    if count is None:
+        return _doctor_result("recent_rows", "pass", "query succeeded; row count unavailable from response")
+    return _doctor_result("recent_rows", "pass", f"{count} row(s) in the last 1h")
+
+
+def _doctor_check_primers_dir():
+    if ACTIVE_ROLE not in _ROLE_PREFIX:
+        return _doctor_result(
+            "primers_dir", "skip", f"role {ACTIVE_ROLE!r} has no associated primer",
+            required=False,
+        )
+    env_dir = os.environ.get("BERSERK_MCP_PRIMERS_DIR", "")
+    if env_dir:
+        try:
+            configured_dir = _validate_store_path(env_dir, "BERSERK_MCP_PRIMERS_DIR")
+        except StorePathError as exc:
+            return _doctor_result(
+                "primers_dir", "fail", f"invalid BERSERK_MCP_PRIMERS_DIR: {exc}",
+                remediation="set BERSERK_MCP_PRIMERS_DIR to an absolute, existing directory",
+            )
+        primer_path = configured_dir / f"{ACTIVE_ROLE}.md"
+        if not primer_path.is_file():
+            return _doctor_result(
+                "primers_dir", "fail", f"{primer_path} not found",
+                remediation=f"add {ACTIVE_ROLE}.md under BERSERK_MCP_PRIMERS_DIR, or unset it to use the built-in primer",
+            )
+        return _doctor_result("primers_dir", "pass", f"{primer_path} readable")
+    search_dirs = [
+        Path(__file__).parent / "primers",
+        Path(sys.prefix) / "share" / "berserk-mcp" / "primers",
+    ]
+    for primer_dir in search_dirs:
+        if (primer_dir / f"{ACTIVE_ROLE}.md").is_file():
+            return _doctor_result("primers_dir", "pass", f"built-in primer found under {primer_dir}")
+    # No BERSERK_MCP_PRIMERS_DIR override, so a missing built-in primer
+    # degrades gracefully at runtime (empty primer text, not fatal) --
+    # matches _load_primer's own tolerant behavior for this case.
+    return _doctor_result(
+        "primers_dir", "skip", f"no built-in primer for role {ACTIVE_ROLE!r} (non-fatal)",
+        required=False,
+    )
+
+
+def _doctor_check_learned_store_writable():
+    parent = LEARNED_PATH.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return _doctor_result(
+            "learned_store_writable", "fail", f"cannot create {parent}: {exc}",
+            remediation="confirm the parent of BERSERK_MCP_LEARNED_PATH is writable",
+        )
+    if not os.access(parent, os.W_OK):
+        return _doctor_result(
+            "learned_store_writable", "fail", f"{parent} is not writable",
+            remediation="confirm the parent of BERSERK_MCP_LEARNED_PATH is writable",
+        )
+    return _doctor_result("learned_store_writable", "pass", f"{parent} writable")
+
+
+def _doctor_check_http_config():
+    if not HTTP_ENABLE:
+        return _doctor_result(
+            "http_config", "skip", "BERSERK_MCP_HTTP_ENABLE is not set",
+            required=False,
+        )
+    try:
+        # _build_http_config's keyword defaults are bound once at import
+        # time, not at call time -- pass the current module globals
+        # explicitly so this check reflects the live environment, not
+        # whatever the values were when the module was first imported.
+        config = _build_http_config(
+            enable=HTTP_ENABLE,
+            bind=HTTP_BIND,
+            allow_remote=HTTP_ALLOW_REMOTE,
+            auth_token=HTTP_AUTH_TOKEN,
+            allowed_hosts=HTTP_ALLOWED_HOSTS,
+            allow_cidrs=HTTP_ALLOW_CIDRS,
+            max_request_bytes=HTTP_MAX_REQUEST_BYTES,
+            max_concurrent_requests=HTTP_MAX_CONCURRENT_REQUESTS,
+            use_forwarded_for=HTTP_USE_FORWARDED_FOR,
+            trusted_proxy_cidrs=HTTP_TRUSTED_PROXY_CIDRS,
+        )
+    except HttpConfigError as exc:
+        return _doctor_result(
+            "http_config", "fail", str(exc),
+            remediation="fix the HTTP env var named in the error above",
+        )
+    return _doctor_result("http_config", "pass", f"coherent, binds {config['host']}:{config['port']}")
+
+
+def _doctor_check_llm_reachability():
+    configured = bool(os.environ.get("BERSERK_LLM_HERMES_URL")) or bool(
+        parser_factory._llm_config().get("hermes_url")
+    )
+    if not configured:
+        return _doctor_result(
+            "llm_hermes_reachability", "skip",
+            "BERSERK_LLM_HERMES_URL not set; generation features are optional",
+            required=False,
+        )
+    url = parser_factory._hermes_url()
+    models_url = url.rsplit("/", 3)[0] + "/api/models" if "/api/" in url else None
+    if not models_url:
+        return _doctor_result(
+            "llm_hermes_reachability", "fail", f"cannot derive /api/models from {url!r}",
+            remediation="confirm BERSERK_LLM_HERMES_URL points at a chat/completions endpoint",
+            required=False,
+        )
+    key = os.environ.get("HERMES_API_KEY", "")
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    _out, err = _http.http_get_json(models_url, headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT)
+    if err:
+        return _doctor_result(
+            "llm_hermes_reachability", "fail", f"unreachable at {models_url}: {err}",
+            remediation="confirm Hermes is running and BERSERK_LLM_HERMES_URL is correct",
+            required=False,
+        )
+    return _doctor_result("llm_hermes_reachability", "pass", f"reachable at {models_url}", required=False)
+
+
+def _doctor_check_canonloom_reachability():
+    server_url = os.environ.get("CANONLOOM_SERVER_URL", "").rstrip("/")
+    if not server_url:
+        return _doctor_result(
+            "canonloom_reachability", "skip",
+            "CANONLOOM_SERVER_URL not set; CanonLoom tools are optional",
+            required=False,
+        )
+    headers = {"Content-Type": "application/json"}
+    api_key = os.environ.get("CANONLOOM_API_KEY")
+    if api_key:
+        headers["X-API-Key"] = api_key
+    _out, err = _http.http_get_json(
+        server_url + "/artifacts", headers, timeout=_DOCTOR_REACHABILITY_TIMEOUT
+    )
+    if err:
+        return _doctor_result(
+            "canonloom_reachability", "fail", f"unreachable at {server_url}: {err}",
+            remediation="confirm canonloom-server is running at CANONLOOM_SERVER_URL",
+            required=False,
+        )
+    return _doctor_result("canonloom_reachability", "pass", f"reachable at {server_url}", required=False)
+
+
+def _run_doctor_checks():
+    """Ordered preflight checks. Each runs independently -- one failing
+    check does not skip the rest, so a single invocation gives the fullest
+    possible picture in one pass."""
+    return [
+        _doctor_check_bzrk_resolvable(),
+        _doctor_check_bzrk_version(),
+        _doctor_check_auth(),
+        _doctor_check_table_reachable(),
+        _doctor_check_recent_rows(),
+        _doctor_check_primers_dir(),
+        _doctor_check_learned_store_writable(),
+        _doctor_check_http_config(),
+        _doctor_check_llm_reachability(),
+        _doctor_check_canonloom_reachability(),
+    ]
+
+
+def _doctor_exit_code(results):
+    """0 pass / 1 degraded / 2 broken. A failed required check means the
+    server cannot do its core job (broken); a failed optional check means
+    an opt-in integration isn't working but the server still can
+    (degraded); skips never lower the exit code."""
+    if any(r["status"] == "fail" and r.get("required", True) for r in results):
+        return 2
+    if any(r["status"] == "fail" for r in results):
+        return 1
+    return 0
+
+
+def _format_doctor_table(results):
+    lines = [f"{'CHECK':<28} {'STATUS':<6} DETAIL"]
+    for r in results:
+        lines.append(f"{r['name']:<28} {r['status'].upper():<6} {r['detail']}")
+        if r["status"] == "fail" and r.get("remediation"):
+            lines.append(f"{'':<28} {'':<6} -> {r['remediation']}")
+    return "\n".join(lines)
+
+
+def run_doctor(json_output=False):
+    """Preflight readiness check. Prints a pass/fail/skip table (or JSON
+    with --json) and returns 0/1/2 -- usable as a fleet readiness probe or
+    a container healthcheck, not just interactive output."""
+    results = _run_doctor_checks()
+    code = _doctor_exit_code(results)
+    if json_output:
+        print(json.dumps({"checks": results, "exit_code": code}, indent=2, sort_keys=True))
+    else:
+        print(_format_doctor_table(results))
+    return code
+
+
 def main():
     import argparse
     cli = argparse.ArgumentParser(
@@ -3732,7 +4032,13 @@ def main():
                      help="persist the Hermes LLM endpoint and exit")
     cli.add_argument("--http", action="store_true",
                      help="serve HTTP transport instead of stdio; requires BERSERK_MCP_HTTP_ENABLE=1")
+    cli.add_argument("--doctor", action="store_true",
+                     help="run preflight readiness checks and exit (0 pass / 1 degraded / 2 broken)")
+    cli.add_argument("--json", action="store_true",
+                     help="(--doctor) emit the report as JSON instead of a table")
     ns = cli.parse_args()
+    if ns.doctor:
+        sys.exit(run_doctor(json_output=ns.json))
     if ns.import_business_data:
         if not ns.input:
             cli.error("--import-business-data requires --input")

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -4056,11 +4056,17 @@ class DoctorPreflightTest(unittest.TestCase):
 
     # ---- bzrk resolvable ----
     def test_bzrk_resolvable_pass_when_found_on_path(self):
-        result = bm._doctor_check_bzrk_resolvable(
-            "bzrk", which=lambda name: "/usr/local/bin/bzrk"
-        )
+        # A hardcoded POSIX path like "/usr/local/bin/bzrk" isn't absolute on
+        # Windows (no drive letter), so Path.resolve() rewrites it relative
+        # to the current drive instead of preserving it -- use a path that's
+        # genuinely absolute on whichever platform the test runs on. Pre-
+        # resolve it (e.g. macOS /tmp -> /private/tmp) so the function's own
+        # .resolve() call is a no-op and can't change the string out from
+        # under the assertion.
+        fake_path = str((Path(self._tmp.name) / "bzrk").resolve(strict=False))
+        result = bm._doctor_check_bzrk_resolvable("bzrk", which=lambda name: fake_path)
         self.assertEqual(result["status"], "pass")
-        self.assertIn("/usr/local/bin/bzrk", result["detail"])
+        self.assertIn(fake_path, result["detail"])
 
     def test_bzrk_resolvable_fail_when_not_found(self):
         result = bm._doctor_check_bzrk_resolvable("bzrk", which=lambda name: None)
@@ -4162,6 +4168,11 @@ class DoctorPreflightTest(unittest.TestCase):
         finally:
             bm.LEARNED_PATH = orig
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "POSIX permission bits aren't enforced the same way on Windows; "
+        "chmod doesn't reliably block directory-content creation there.",
+    )
     def test_learned_store_writable_fail_when_parent_not_writable(self):
         orig = bm.LEARNED_PATH
         readonly_dir = Path(self._tmp.name) / "readonly"

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -4016,8 +4016,30 @@ class DoctorPreflightTest(unittest.TestCase):
         self._orig_run_bzrk = bm.run_bzrk
         self._tmp = tempfile.TemporaryDirectory()
 
+        # Isolate every check the aggregator (_run_doctor_checks/run_doctor/
+        # self_check) can reach from whatever the real machine happens to
+        # have: bzrk on PATH varies (present on a dev machine, absent on a
+        # clean CI runner -- this exact gap failed CI while passing
+        # locally), and a persisted Hermes/CanonLoom config is real
+        # operator state a test must never depend on or disturb. Individual
+        # checks that need the un-isolated real behavior (e.g.
+        # test_bzrk_resolvable_fail_when_not_found) pass which=/etc.
+        # directly to the single-check function, which overrides this.
+        self._orig_which = bm.shutil.which
+        bm.shutil.which = lambda name: "/usr/bin/bzrk"
+        self._orig_llm_config = bm.parser_factory._llm_config
+        bm.parser_factory._llm_config = lambda: {}
+        self._orig_hermes_env = os.environ.pop("BERSERK_LLM_HERMES_URL", None)
+        self._orig_canonloom_env = os.environ.pop("CANONLOOM_SERVER_URL", None)
+
     def tearDown(self):
         bm.run_bzrk = self._orig_run_bzrk
+        bm.shutil.which = self._orig_which
+        bm.parser_factory._llm_config = self._orig_llm_config
+        if self._orig_hermes_env is not None:
+            os.environ["BERSERK_LLM_HERMES_URL"] = self._orig_hermes_env
+        if self._orig_canonloom_env is not None:
+            os.environ["CANONLOOM_SERVER_URL"] = self._orig_canonloom_env
         self._tmp.cleanup()
 
     def _fake_run_bzrk(self, response_map):

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -4006,5 +4006,312 @@ class SinceNormalizerTest(unittest.TestCase):
             bm.run_bzrk = orig
 
 
+class DoctorPreflightTest(unittest.TestCase):
+    """--doctor / self_check: ordered preflight checks with pass/fail/skip
+    status, one remediation line per failure, and an exit code a fleet
+    readiness probe or container healthcheck can act on."""
+
+    def setUp(self):
+        self.calls = []
+        self._orig_run_bzrk = bm.run_bzrk
+        self._tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        bm.run_bzrk = self._orig_run_bzrk
+        self._tmp.cleanup()
+
+    def _fake_run_bzrk(self, response_map):
+        """response_map: dict of substring-in-argv -> (text, is_err), checked
+        in insertion order; first match wins."""
+        def fake(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            joined = " ".join(str(a) for a in args)
+            for needle, result in response_map.items():
+                if needle in joined:
+                    return result
+            return ("OK", False)
+        return fake
+
+    # ---- bzrk resolvable ----
+    def test_bzrk_resolvable_pass_when_found_on_path(self):
+        result = bm._doctor_check_bzrk_resolvable(
+            "bzrk", which=lambda name: "/usr/local/bin/bzrk"
+        )
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("/usr/local/bin/bzrk", result["detail"])
+
+    def test_bzrk_resolvable_fail_when_not_found(self):
+        result = bm._doctor_check_bzrk_resolvable("bzrk", which=lambda name: None)
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("remediation", result)
+        self.assertTrue(result["remediation"])
+
+    # ---- bzrk version ----
+    def test_bzrk_version_pass_on_success(self):
+        bm.run_bzrk = self._fake_run_bzrk({"--version": ("bzrk 2026-06-30.abc123", False)})
+        result = bm._doctor_check_bzrk_version()
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("2026-06-30.abc123", result["detail"])
+
+    def test_bzrk_version_fail_on_error(self):
+        bm.run_bzrk = self._fake_run_bzrk({"--version": ("command not found", True)})
+        result = bm._doctor_check_bzrk_version()
+        self.assertEqual(result["status"], "fail")
+
+    # ---- auth ----
+    def test_auth_pass_when_query_succeeds(self):
+        bm.run_bzrk = self._fake_run_bzrk({})
+        result = bm._doctor_check_auth()
+        self.assertEqual(result["status"], "pass")
+
+    def test_auth_fail_on_auth_failure_message(self):
+        bm.run_bzrk = self._fake_run_bzrk({"search": (bm.AUTH_FAILURE_MESSAGE, True)})
+        result = bm._doctor_check_auth()
+        self.assertEqual(result["status"], "fail")
+        self.assertIn("bzrk login", result["remediation"])
+
+    # ---- table reachable ----
+    def test_table_reachable_pass(self):
+        bm.run_bzrk = self._fake_run_bzrk({})
+        result = bm._doctor_check_table_reachable()
+        self.assertEqual(result["status"], "pass")
+
+    def test_table_reachable_fail(self):
+        bm.run_bzrk = self._fake_run_bzrk({"search": ("PARSE ERROR", True)})
+        result = bm._doctor_check_table_reachable()
+        self.assertEqual(result["status"], "fail")
+
+    # ---- recent rows ----
+    def test_recent_rows_reports_count_on_success(self):
+        # Real bzrk shape for `| count` with --json (confirmed live):
+        # {"Tables": [{"schema": {"columns": [{"name": "Count"}]}, "rows": [[42]]}]}
+        doc = {"Tables": [{"schema": {"columns": [{"name": "Count"}]}, "rows": [[42]]}]}
+        bm.run_bzrk = self._fake_run_bzrk({"--json": (json.dumps(doc), False)})
+        result = bm._doctor_check_recent_rows()
+        self.assertEqual(result["status"], "pass")
+        self.assertIn("42", result["detail"])
+
+    def test_recent_rows_fail_when_query_errors(self):
+        bm.run_bzrk = self._fake_run_bzrk({"--json": ("PARSE ERROR", True)})
+        result = bm._doctor_check_recent_rows()
+        self.assertEqual(result["status"], "fail")
+
+    # ---- primers dir ----
+    def test_primers_dir_skip_for_role_without_a_primer(self):
+        orig = bm.ACTIVE_ROLE
+        try:
+            bm.ACTIVE_ROLE = "all"
+            result = bm._doctor_check_primers_dir()
+            self.assertEqual(result["status"], "skip")
+        finally:
+            bm.ACTIVE_ROLE = orig
+
+    def test_primers_dir_pass_for_builtin_role_primer(self):
+        orig = bm.ACTIVE_ROLE
+        try:
+            bm.ACTIVE_ROLE = "sre"
+            result = bm._doctor_check_primers_dir()
+            self.assertEqual(result["status"], "pass")
+        finally:
+            bm.ACTIVE_ROLE = orig
+
+    def test_primers_dir_fail_when_explicit_dir_missing_file(self):
+        orig_role = bm.ACTIVE_ROLE
+        orig_env = os.environ.get("BERSERK_MCP_PRIMERS_DIR")
+        try:
+            bm.ACTIVE_ROLE = "sre"
+            os.environ["BERSERK_MCP_PRIMERS_DIR"] = self._tmp.name
+            result = bm._doctor_check_primers_dir()
+            self.assertEqual(result["status"], "fail")
+        finally:
+            bm.ACTIVE_ROLE = orig_role
+            if orig_env is None:
+                os.environ.pop("BERSERK_MCP_PRIMERS_DIR", None)
+            else:
+                os.environ["BERSERK_MCP_PRIMERS_DIR"] = orig_env
+
+    # ---- learned store writable ----
+    def test_learned_store_writable_pass(self):
+        orig = bm.LEARNED_PATH
+        try:
+            bm.LEARNED_PATH = Path(self._tmp.name) / "sub" / "learned.json"
+            result = bm._doctor_check_learned_store_writable()
+            self.assertEqual(result["status"], "pass")
+        finally:
+            bm.LEARNED_PATH = orig
+
+    def test_learned_store_writable_fail_when_parent_not_writable(self):
+        orig = bm.LEARNED_PATH
+        readonly_dir = Path(self._tmp.name) / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o500)
+        try:
+            bm.LEARNED_PATH = readonly_dir / "nested" / "learned.json"
+            result = bm._doctor_check_learned_store_writable()
+            self.assertEqual(result["status"], "fail")
+        finally:
+            readonly_dir.chmod(0o700)
+            bm.LEARNED_PATH = orig
+
+    # ---- http config ----
+    def test_http_config_skip_when_disabled(self):
+        orig = bm.HTTP_ENABLE
+        try:
+            bm.HTTP_ENABLE = False
+            result = bm._doctor_check_http_config()
+            self.assertEqual(result["status"], "skip")
+        finally:
+            bm.HTTP_ENABLE = orig
+
+    def test_http_config_pass_when_enabled_and_coherent(self):
+        orig = bm.HTTP_ENABLE
+        try:
+            bm.HTTP_ENABLE = True
+            result = bm._doctor_check_http_config()
+            self.assertEqual(result["status"], "pass")
+        finally:
+            bm.HTTP_ENABLE = orig
+
+    def test_http_config_fail_when_enabled_and_incoherent(self):
+        orig_enable = bm.HTTP_ENABLE
+        orig_bind = bm.HTTP_BIND
+        try:
+            bm.HTTP_ENABLE = True
+            bm.HTTP_BIND = "not-a-valid-bind"
+            result = bm._doctor_check_http_config()
+            self.assertEqual(result["status"], "fail")
+        finally:
+            bm.HTTP_ENABLE = orig_enable
+            bm.HTTP_BIND = orig_bind
+
+    # ---- LLM/CanonLoom reachability: skip when unconfigured ----
+    def test_llm_reachability_skip_when_unconfigured(self):
+        # Isolate from whatever is actually persisted on the machine running
+        # the tests (parser_factory._llm_config() reads a real per-user
+        # config file, e.g. an operator's genuinely configured Hermes URL --
+        # not something a test should depend on or disturb).
+        orig_env = os.environ.pop("BERSERK_LLM_HERMES_URL", None)
+        orig_llm_config = bm.parser_factory._llm_config
+        bm.parser_factory._llm_config = lambda: {}
+        try:
+            result = bm._doctor_check_llm_reachability()
+            self.assertEqual(result["status"], "skip")
+        finally:
+            bm.parser_factory._llm_config = orig_llm_config
+            if orig_env is not None:
+                os.environ["BERSERK_LLM_HERMES_URL"] = orig_env
+
+    def test_canonloom_reachability_skip_when_unconfigured(self):
+        orig = os.environ.pop("CANONLOOM_SERVER_URL", None)
+        try:
+            result = bm._doctor_check_canonloom_reachability()
+            self.assertEqual(result["status"], "skip")
+        finally:
+            if orig is not None:
+                os.environ["CANONLOOM_SERVER_URL"] = orig
+
+    # ---- aggregation and exit code ----
+    def test_run_doctor_checks_returns_all_checks_in_order(self):
+        bm.run_bzrk = self._fake_run_bzrk({})
+        results = bm._run_doctor_checks()
+        names = [r["name"] for r in results]
+        self.assertEqual(len(names), len(set(names)), "duplicate check names")
+        self.assertIn("bzrk_resolvable", names)
+        self.assertIn("llm_hermes_reachability", names)
+        self.assertIn("canonloom_reachability", names)
+
+    def test_exit_code_zero_when_all_pass_or_skip(self):
+        results = [
+            {"name": "a", "status": "pass", "required": True},
+            {"name": "b", "status": "skip", "required": False},
+        ]
+        self.assertEqual(bm._doctor_exit_code(results), 0)
+
+    def test_exit_code_two_when_a_required_check_fails(self):
+        results = [
+            {"name": "a", "status": "fail", "required": True, "remediation": "x"},
+            {"name": "b", "status": "pass", "required": False},
+        ]
+        self.assertEqual(bm._doctor_exit_code(results), 2)
+
+    def test_exit_code_one_when_only_an_optional_check_fails(self):
+        results = [
+            {"name": "a", "status": "pass", "required": True},
+            {"name": "b", "status": "fail", "required": False, "remediation": "x"},
+        ]
+        self.assertEqual(bm._doctor_exit_code(results), 1)
+
+    # ---- self_check tool ----
+    def test_self_check_tool_returns_json_report(self):
+        bm.run_bzrk = self._fake_run_bzrk({})
+        text, err = bm.handle_call("self_check", {})
+        self.assertFalse(err)
+        report = json.loads(text)
+        self.assertIn("checks", report)
+        self.assertIn("exit_code", report)
+
+    # ---- run_doctor (CLI entry point) ----
+    def test_run_doctor_returns_exit_code_and_prints_table(self):
+        bm.run_bzrk = self._fake_run_bzrk({})
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = bm.run_doctor()
+        self.assertIsInstance(code, int)
+        self.assertIn("bzrk_resolvable", buf.getvalue())
+
+
+class EnvExampleDriftTest(unittest.TestCase):
+    """Every env var this codebase actually reads must be documented in
+    .env.example, or an operator has no way to discover it short of reading
+    ~4,000 lines of source. Catches the gap silently reopening as new env
+    reads are added without a matching doc line."""
+
+    _ENV_READ_RE = re.compile(
+        r"os\.environ(?:\.get)?\s*[\(\[]\s*[\"']([A-Z_][A-Z0-9_]*)[\"']"
+        r"|os\.getenv\s*\(\s*[\"']([A-Z_][A-Z0-9_]*)[\"']"
+        r"|_(?:nonnegative_int_env|nonnegative_float_env|choice_env)\s*"
+        r"\(\s*[\"']([A-Z_][A-Z0-9_]*)[\"']",
+        re.DOTALL,
+    )
+    _SCANNED_FILES = (
+        "berserk_mcp.py", "agent_analytics.py", "ai_finops.py",
+        "ingestion_advisor.py", "schema_registry.py", "kql_validation.py",
+        "parser_factory.py", "secret_scan.py", "_http.py",
+    )
+    _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+    def _vars_read_in_source(self):
+        found = set()
+        for fname in self._SCANNED_FILES:
+            path = self._REPO_ROOT / fname
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8")
+            for m in self._ENV_READ_RE.finditer(text):
+                found.add(next(g for g in m.groups() if g))
+        return found
+
+    def _vars_documented_in_env_example(self):
+        path = self._REPO_ROOT / ".env.example"
+        text = path.read_text(encoding="utf-8")
+        return set(re.findall(r"^#?\s*([A-Z_][A-Z0-9_]*)=", text, re.MULTILINE))
+
+    def test_every_source_env_read_is_documented(self):
+        missing = self._vars_read_in_source() - self._vars_documented_in_env_example()
+        self.assertEqual(
+            missing, set(),
+            f".env.example is missing: {sorted(missing)}",
+        )
+
+    def test_no_stale_entries_for_vars_no_longer_read(self):
+        stale = self._vars_documented_in_env_example() - self._vars_read_in_source()
+        self.assertEqual(
+            stale, set(),
+            f".env.example documents vars no longer read in source: {sorted(stale)}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -4044,13 +4044,22 @@ class DoctorPreflightTest(unittest.TestCase):
 
     def _fake_run_bzrk(self, response_map):
         """response_map: dict of substring-in-argv -> (text, is_err), checked
-        in insertion order; first match wins."""
+        in insertion order; first match wins. Falls back to realistic
+        default responses for --version and a --json `| count` query (the
+        two bzrk_version/recent_rows now validate the shape of, not just
+        the exit code) so tests exercising the full aggregator don't need
+        to know about that validation unless they're specifically testing it."""
         def fake(args, timeout=bm.DEFAULT_TIMEOUT):
             self.calls.append(list(args))
             joined = " ".join(str(a) for a in args)
             for needle, result in response_map.items():
                 if needle in joined:
                     return result
+            if "--version" in joined:
+                return ("bzrk 2026-06-30.abc123", False)
+            if "--json" in joined and "count" in joined:
+                doc = {"Tables": [{"schema": {"columns": [{"name": "Count"}]}, "rows": [[1]]}]}
+                return (json.dumps(doc), False)
             return ("OK", False)
         return fake
 
@@ -4097,6 +4106,20 @@ class DoctorPreflightTest(unittest.TestCase):
         result = bm._doctor_check_auth()
         self.assertEqual(result["status"], "fail")
         self.assertIn("bzrk login", result["remediation"])
+
+    def test_auth_failure_skips_dependent_checks_instead_of_relabeling_them(self):
+        # Codex review finding #4: table_reachable and recent_rows run their
+        # own query against the same profile, so a stale login makes all
+        # three independently "fail" -- three misleading remediations for
+        # one root cause. Once auth has failed, the dependent checks should
+        # report skip (unknown, not independently broken) rather than
+        # re-running the same doomed query.
+        bm.run_bzrk = self._fake_run_bzrk({"search": (bm.AUTH_FAILURE_MESSAGE, True)})
+        results = bm._run_doctor_checks()
+        by_name = {r["name"]: r for r in results}
+        self.assertEqual(by_name["auth"]["status"], "fail")
+        self.assertEqual(by_name["table_reachable"]["status"], "skip")
+        self.assertEqual(by_name["recent_rows"]["status"], "skip")
 
     # ---- table reachable ----
     def test_table_reachable_pass(self):
@@ -4168,6 +4191,21 @@ class DoctorPreflightTest(unittest.TestCase):
         finally:
             bm.LEARNED_PATH = orig
 
+    def test_learned_store_writable_fail_when_target_is_a_directory(self):
+        # Codex review finding #5: checking only LEARNED_PATH.parent misses
+        # the case where LEARNED_PATH itself already exists as a directory
+        # -- the parent is writable, so the old check passed, but the
+        # actual atomic save then fails with IsADirectoryError.
+        orig = bm.LEARNED_PATH
+        target_as_dir = Path(self._tmp.name) / "learned.json"
+        target_as_dir.mkdir()
+        try:
+            bm.LEARNED_PATH = target_as_dir
+            result = bm._doctor_check_learned_store_writable()
+            self.assertEqual(result["status"], "fail")
+        finally:
+            bm.LEARNED_PATH = orig
+
     @unittest.skipIf(
         os.name == "nt",
         "POSIX permission bits aren't enforced the same way on Windows; "
@@ -4217,18 +4255,54 @@ class DoctorPreflightTest(unittest.TestCase):
             bm.HTTP_ENABLE = orig_enable
             bm.HTTP_BIND = orig_bind
 
-    # ---- LLM/CanonLoom reachability: skip when unconfigured ----
-    def test_llm_reachability_skip_when_unconfigured(self):
-        # Isolate from whatever is actually persisted on the machine running
-        # the tests (parser_factory._llm_config() reads a real per-user
-        # config file, e.g. an operator's genuinely configured Hermes URL --
-        # not something a test should depend on or disturb).
+    # ---- wall-clock timeout wrapper ----
+    def test_with_wall_clock_timeout_returns_promptly_on_a_slow_call(self):
+        # Codex review finding #6: urllib's timeout= only bounds individual
+        # socket read/connect operations, not total wall-clock time -- a
+        # server trickling bytes just inside that window per read (measured:
+        # 8.02s wall clock against a 5s per-op timeout) can keep a request
+        # open far longer than the advertised deadline implies. This wrapper
+        # bounds how long the CALLER waits, even though the underlying call
+        # may keep running in the background (Python can't forcibly kill a
+        # thread -- that's an accepted, documented tradeoff, not a leak bug).
+        import time as _time
+
+        def slow_call():
+            _time.sleep(2)
+            return "done"
+
+        start = _time.monotonic()
+        result = bm._with_wall_clock_timeout(slow_call, timeout=0.2)
+        elapsed = _time.monotonic() - start
+        self.assertIsNone(result)
+        self.assertLess(elapsed, 1.0, "wrapper should not wait for the slow call to finish")
+
+    def test_with_wall_clock_timeout_returns_the_real_result_when_fast_enough(self):
+        result = bm._with_wall_clock_timeout(lambda: ("value", None), timeout=5)
+        self.assertEqual(result, ("value", None))
+
+    # ---- LLM/CanonLoom reachability ----
+    def test_llm_reachability_probes_implicit_default_when_unconfigured(self):
+        # Codex review finding #3: runtime parser_factory._hermes_url()
+        # always resolves to SOME URL, falling back to a hardcoded
+        # localhost default -- generation features attempt that default
+        # even with nothing explicitly configured. The old "skip when no
+        # explicit config" behavior meant Doctor reported exit_code=0 while
+        # generation would fail outright hitting an unreachable default.
+        # It must never silently skip -- always attempt the real effective
+        # URL, staying optional (required=False) so an operator who never
+        # uses generation features still isn't pushed to "broken".
+        #
+        # Isolate from whatever is actually persisted on the machine
+        # running the tests (parser_factory._llm_config() reads a real
+        # per-user config file -- not something a test should depend on).
         orig_env = os.environ.pop("BERSERK_LLM_HERMES_URL", None)
         orig_llm_config = bm.parser_factory._llm_config
         bm.parser_factory._llm_config = lambda: {}
         try:
             result = bm._doctor_check_llm_reachability()
-            self.assertEqual(result["status"], "skip")
+            self.assertNotEqual(result["status"], "skip")
+            self.assertFalse(result.get("required", True))
         finally:
             bm.parser_factory._llm_config = orig_llm_config
             if orig_env is not None:
@@ -4252,6 +4326,47 @@ class DoctorPreflightTest(unittest.TestCase):
         self.assertIn("bzrk_resolvable", names)
         self.assertIn("llm_hermes_reachability", names)
         self.assertIn("canonloom_reachability", names)
+
+    def test_one_check_raising_does_not_abort_the_whole_report(self):
+        # Codex review finding #2: a malformed bzrk response can make
+        # agent_analytics._json_records raise AttributeError deep inside
+        # _doctor_check_recent_rows. Without per-check isolation that
+        # crashes _run_doctor_checks entirely -- the whole report is lost
+        # over one bad check, defeating the point of a preflight tool that
+        # should never itself crash.
+        bm.run_bzrk = self._fake_run_bzrk({
+            "--json": ('{"Tables":[{"schema":"changed-shape","rows":[]}]}', False)
+        })
+        results = bm._run_doctor_checks()
+        names = [r["name"] for r in results]
+        self.assertIn("bzrk_resolvable", names)
+        self.assertIn("canonloom_reachability", names)
+        recent_rows = next(r for r in results if r["name"] == "recent_rows")
+        self.assertEqual(recent_rows["status"], "fail")
+
+    def test_bzrk_version_fails_on_output_that_is_not_a_version_string(self):
+        # Codex review finding #2: any exit-zero output (including
+        # run_bzrk's synthetic "(no rows)") was accepted as a valid version,
+        # letting an unrelated executable (e.g. BZRK_BIN=/usr/bin/true)
+        # satisfy this required check.
+        bm.run_bzrk = self._fake_run_bzrk({"--version": ("(no rows)", False)})
+        result = bm._doctor_check_bzrk_version()
+        self.assertEqual(result["status"], "fail")
+
+    def test_bzrk_version_fails_on_empty_output(self):
+        bm.run_bzrk = self._fake_run_bzrk({"--version": ("", False)})
+        result = bm._doctor_check_bzrk_version()
+        self.assertEqual(result["status"], "fail")
+
+    def test_recent_rows_fails_when_count_field_is_missing(self):
+        # Previously reported "pass" with "row count unavailable" -- for a
+        # *required* check that's a silent pass on missing evidence, exactly
+        # the kind of unrelated-executable-satisfies-everything gap Codex
+        # flagged for bzrk_version.
+        doc = {"Tables": [{"schema": {"columns": [{"name": "NotCount"}]}, "rows": [[1]]}]}
+        bm.run_bzrk = self._fake_run_bzrk({"--json": (json.dumps(doc), False)})
+        result = bm._doctor_check_recent_rows()
+        self.assertEqual(result["status"], "fail")
 
     def test_exit_code_zero_when_all_pass_or_skip(self):
         results = [
@@ -4299,28 +4414,34 @@ class EnvExampleDriftTest(unittest.TestCase):
     """Every env var this codebase actually reads must be documented in
     .env.example, or an operator has no way to discover it short of reading
     ~4,000 lines of source. Catches the gap silently reopening as new env
-    reads are added without a matching doc line."""
+    reads are added without a matching doc line.
+
+    Known limitation (Codex review, not fixed): parser_factory.py builds one
+    env var name dynamically -- f"BERSERK_LLM_{provider.upper()}_MODEL" --
+    from the active BERSERK_LLM_LADDER provider. A static regex can never
+    prove what that resolves to. In practice it's covered anyway: the
+    ladder's three providers (hermes/openai/anthropic) each already have
+    their MODEL var documented as a literal elsewhere in this file. An
+    entirely new provider name would need its own literal os.environ.get
+    call to work at all, which this guard would then catch normally."""
 
     _ENV_READ_RE = re.compile(
         r"os\.environ(?:\.get)?\s*[\(\[]\s*[\"']([A-Z_][A-Z0-9_]*)[\"']"
         r"|os\.getenv\s*\(\s*[\"']([A-Z_][A-Z0-9_]*)[\"']"
-        r"|_(?:nonnegative_int_env|nonnegative_float_env|choice_env)\s*"
+        r"|_(?:nonnegative_int_env|nonnegative_float_env|choice_env|"
+        r"optional_absolute_env_path)\s*"
         r"\(\s*[\"']([A-Z_][A-Z0-9_]*)[\"']",
         re.DOTALL,
-    )
-    _SCANNED_FILES = (
-        "berserk_mcp.py", "agent_analytics.py", "ai_finops.py",
-        "ingestion_advisor.py", "schema_registry.py", "kql_validation.py",
-        "parser_factory.py", "secret_scan.py", "_http.py",
     )
     _REPO_ROOT = Path(__file__).resolve().parent.parent
 
     def _vars_read_in_source(self):
+        # Scan every top-level production module rather than a hand-kept
+        # file list, so a newly added module can't silently bypass this
+        # guard the way _store.py did (never in the original list, and its
+        # own env reads went undetected until this fix).
         found = set()
-        for fname in self._SCANNED_FILES:
-            path = self._REPO_ROOT / fname
-            if not path.is_file():
-                continue
+        for path in sorted(self._REPO_ROOT.glob("*.py")):
             text = path.read_text(encoding="utf-8")
             for m in self._ENV_READ_RE.finditer(text):
                 found.add(next(g for g in m.groups() if g))


### PR DESCRIPTION
Closes #6.

## Summary

`berserk-mcp --doctor` (add `--json` for machine-readable output): 9 ordered preflight checks, pass/fail/skip table, one remediation line per failure, exit code 0/1/2 (pass/degraded/broken). `self_check` MCP tool exposes the same checks so an agent hitting repeated tool errors can diagnose wiring itself (`isError` only on "broken"). `.env.example` extended from 11 to full coverage of every env var actually read in the codebase, backed by a drift-guard test.

Went through a full Codex differential review (2 P1, 5 P2) after initial CI green. Summary of what changed in response — see commit history for full detail on each:

- **Crash resistance**: `_run_doctor_checks()` now isolates each check; one check raising an unexpected exception no longer takes down the whole report.
- **Required checks now need real evidence**: `bzrk_version` and `recent_rows` previously accepted any exit-zero output, so an unrelated executable pointed at by `BZRK_BIN` could satisfy every required bzrk check. Both now validate the actual response shape.
- **Hermes reachability now reflects the real runtime default**: `parser_factory._hermes_url()` always resolves to *some* URL (falling back to a hardcoded localhost default), so the check no longer silently skips just because nothing was explicitly configured — it always probes the effective URL, staying optional so it can't push exit code past "degraded".
- **Auth-failure cascade fixed**: `table_reachable`/`recent_rows` query the same profile as `auth`; when auth has already failed they now report `skip` (pointing at the auth failure) instead of independently re-failing and reading as three separate problems.
- **Learned-store check tests the real target**: previously checked only the parent directory, missing the case where `LEARNED_PATH` itself already exists as a directory.
- **Wall-clock timeout enforced**: `urllib`'s `timeout=` only bounds individual socket operations, not total time (confirmed: a slow-drip server kept a request open 8s against a 5s setting). Added a daemon-thread-based wrapper that bounds how long the caller actually waits.
- **`.env.example` gap closed + scanning hardened**: found 4 more real env reads (via a helper function the original regex didn't recognize) and switched from a hand-kept file list to scanning every top-level module, since the original list never included `_store.py` at all.
- **One finding documented, not fixed**: an invalid `BZRK_BIN` or a `BERSERK_MCP_PRIMERS_DIR` pointed at a missing file both fail the whole process at import time, before `--doctor` can run. That's pre-existing, deliberate fail-fast behavior predating this PR; weakening it to let `--doctor` limp past would weaken it everywhere else too. Documented as a stated limitation in `run_doctor()`'s docstring instead.

## Test plan
- [x] All checks + aggregation + exit-code logic + crash isolation + `self_check` + `run_doctor()` CLI, written test-first throughout (TDD, confirmed RED before every GREEN, across all review rounds)
- [x] `.env.example` drift guard (missing entries, stale entries)
- [x] Smoke-tested `--doctor`/`--doctor --json` against the live cluster
- [x] Reproduced and verified every review finding directly (e.g. `BZRK_BIN=/usr/bin/true` no longer satisfies required checks; malformed JSON shape no longer crashes the report)
- [x] `python tests/test_berserk_mcp.py` — 319 tests, all pass
- [x] `python -m unittest discover -s tests` — 672 tests, all pass (1 pre-existing unrelated skip)
- [x] `python evals/mcp_protocol_smoke.py --include-http` — all pass
- [x] CI green across the full matrix (ubuntu/windows × Python 3.9/3.11/3.12) after fixing two Windows-only test-fixture bugs (hardcoded POSIX path, chmod-based permission test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)