### PR TITLE
feat(result-envelope): window/rows header + per-tool empty guidance for SIMPLE path (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,11 @@
 # Hard cap on captured bzrk stdout, in bytes. Default: 10485760 (10 MiB).
 # BERSERK_MCP_MAX_RESULT_BYTES=10485760
 
+# Wrap SIMPLE fixed-query tool output with a window= rows= header and
+# per-tool empty-result guidance. Default: enabled. Set to "0" to restore
+# byte-identical prior output if downstream tooling parses the raw rows.
+# BERSERK_MCP_ENVELOPE=1
+
 # ---------------------------------------------------------------------------
 # KQL validation
 # ---------------------------------------------------------------------------

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -225,6 +225,9 @@ MAX_BZRK_RESULT_BYTES = (
 FINOPS_REDACT_ENTROPY = os.environ.get(
     "BERSERK_MCP_FINOPS_REDACT_ENTROPY", "0"
 ).strip().lower() in {"1", "true", "yes", "on"}
+ENVELOPE_ENABLED = os.environ.get(
+    "BERSERK_MCP_ENVELOPE", "1"
+).strip().lower() not in {"0", "false", "no", "off"}
 _QUERY_SEMAPHORE = threading.BoundedSemaphore(MAX_CONCURRENT_QUERIES) if MAX_CONCURRENT_QUERIES > 0 else None
 
 # Fleet controls are deliberately in-process. An MCP stdio server is one
@@ -1838,6 +1841,82 @@ _SIMPLE_JSON_TOOLS = {
     "sre_top_error_messages", "soc_repeated_errors",
 }
 
+_EMPTY_NEXT_STEP = {
+    "list_containers":
+        "Widen with since='1h ago', or check list_hosts for hosts without containers.",
+    "top_cpu":
+        "For whole-machine CPU use host_cpu; top_cpu is per-container.",
+    "top_memory":
+        "For whole-machine memory use host_memory; top_memory is per-container.",
+    "errors_by_service":
+        "Widen with since='24h ago', or confirm the source is reporting with list_services.",
+    "list_services":
+        "Widen with since='6h ago', or check list_hosts if services are attached to hosts.",
+    "list_hosts":
+        "Widen with since='6h ago', or verify ingest health with sre_ingest_health.",
+    "host_cpu":
+        "For per-container CPU use top_cpu; host_cpu is per-host.",
+    "host_memory":
+        "For per-container memory use top_memory; host_memory is per-host.",
+    "container_hosts":
+        "Widen with since='6h ago', or check list_containers for active containers.",
+    "list_metrics":
+        "Widen with since='6h ago', or verify the source is ingesting with sre_ingest_health.",
+    "bzrk_query_perf":
+        "Widen with since='6h ago'; no query traffic means no perf data to show.",
+    "sre_error_rate":
+        "Widen with since='6h ago', or check errors_by_service for breakdown by service.",
+    "sre_host_headroom":
+        "Widen with since='2h ago'; no headroom data means no host metrics arrived.",
+    "sre_ingest_health":
+        "Widen with since='6h ago'; check list_hosts to see if any hosts are reporting.",
+    "sre_top_error_messages":
+        "Widen with since='6h ago', or check errors_by_service for aggregate counts.",
+    "soc_high_severity_logs":
+        "Widen with since='6h ago', or check soc_log_spike for volume anomalies.",
+    "soc_log_spike":
+        "Widen with since='6h ago'; no spike means no volume anomaly in this window.",
+    "soc_repeated_errors":
+        "Widen with since='24h ago', or check errors_by_service for recent counts.",
+    "claude_recent":
+        "Widen with since='6h ago', or check claude_sessions for session-level activity.",
+    "claude_sessions":
+        "Widen with since='24h ago', or check claude_recent for recent events.",
+    "claude_tools":
+        "Widen with since='24h ago'; no tool data means no Claude Code sessions in this window.",
+    "claude_errors":
+        "Widen with since='24h ago', or check claude_recent to see if sessions are active.",
+    "trace_find_slow":
+        "Widen with since='6h ago'; no slow traces means all spans finished within threshold.",
+    "trace_find_errors":
+        "Widen with since='6h ago', or check errors_by_service for error counts.",
+}
+
+
+def _envelope(tool, since, out):
+    """Wrap SIMPLE tool output with a window/rows header. Never raises."""
+    try:
+        if out.strip() == "(no rows)":
+            next_step = _EMPTY_NEXT_STEP.get(tool, "Try a wider window with since='24h ago'.")
+            return f"No rows in window {since}. {next_step}"
+        stripped = out.strip()
+        if stripped and stripped[0] in "[{":
+            try:
+                records = agent_analytics._json_records(json.loads(stripped))
+                rows = len(records) if records is not None else None
+            except Exception:
+                rows = None
+        else:
+            data_lines = [ln for ln in stripped.splitlines() if ln.strip()]
+            rows = max(0, len(data_lines) - 1)
+        header = f"window={since}"
+        if rows is not None:
+            header = f"{header}  rows={rows}"
+        return f"{header}\n\n{out}"
+    except Exception:
+        return out
+
+
 _QUERY_RISK_BUDGET_MULTIPLIERS = {
     "low": 1.0,
     "medium": 1.5,
@@ -2489,8 +2568,18 @@ def _handle_call_uncached(name, arguments):
         kql, default_since = SIMPLE[name]
         since = arguments.get("since") or default_since
         if name in _SIMPLE_JSON_TOOLS:
-            return bzrk_search_json(kql, since)
-        return bzrk_search(kql, since)
+            out, err = bzrk_search_json(kql, since)
+        else:
+            out, err = bzrk_search(kql, since)
+        if ENVELOPE_ENABLED:
+            if err and out.startswith("bzrk result exceeded"):
+                out = (
+                    f"Result exceeded BERSERK_MCP_MAX_RESULT_BYTES={MAX_BZRK_RESULT_BYTES}."
+                    f" This tool's query is fixed — narrow the window, e.g. since='15m ago'."
+                )
+            elif not err:
+                out = _envelope(name, since, out)
+        return out, err
 
     if name == "soc_new_services":
         since = arguments.get("since") or "24h ago"

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -1845,9 +1845,9 @@ _EMPTY_NEXT_STEP = {
     "list_containers":
         "Widen with since='1h ago', or check list_hosts for hosts without containers.",
     "top_cpu":
-        "For whole-machine CPU use host_cpu; top_cpu is per-container.",
+        "For whole-machine CPU use host_cpu; top_cpu is per-container. If both are empty, widen with since='1h ago'.",
     "top_memory":
-        "For whole-machine memory use host_memory; top_memory is per-container.",
+        "For whole-machine memory use host_memory; top_memory is per-container. If both are empty, widen with since='1h ago'.",
     "errors_by_service":
         "Widen with since='24h ago', or confirm the source is reporting with list_services.",
     "list_services":
@@ -1855,9 +1855,9 @@ _EMPTY_NEXT_STEP = {
     "list_hosts":
         "Widen with since='6h ago', or verify ingest health with sre_ingest_health.",
     "host_cpu":
-        "For per-container CPU use top_cpu; host_cpu is per-host.",
+        "For per-container CPU use top_cpu; host_cpu is per-host. If both are empty, widen with since='1h ago'.",
     "host_memory":
-        "For per-container memory use top_memory; host_memory is per-host.",
+        "For per-container memory use top_memory; host_memory is per-host. If both are empty, widen with since='1h ago'.",
     "container_hosts":
         "Widen with since='6h ago', or check list_containers for active containers.",
     "list_metrics":

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -1283,7 +1283,9 @@ class BerserkMcpTest(unittest.TestCase):
             bm.ENABLE_MCP_2026_07_28 = orig_enabled
         result = resp["result"]
         self.assertEqual(result["resultType"], "complete")
-        self.assertEqual(result["content"], [{"type": "text", "text": "OK"}])
+        self.assertEqual(len(result["content"]), 1)
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("OK", result["content"][0]["text"])  # envelope wraps; raw text preserved
         self.assertFalse(result["isError"])
         self.assertNotIn("structuredContent", result)
 
@@ -1345,7 +1347,9 @@ class BerserkMcpTest(unittest.TestCase):
         finally:
             bm.ENABLE_MCP_2026_07_28 = orig_enabled
         result = resp["result"]
-        self.assertEqual(result["content"], [{"type": "text", "text": "OK"}])
+        self.assertEqual(len(result["content"]), 1)
+        self.assertEqual(result["content"][0]["type"], "text")
+        self.assertIn("OK", result["content"][0]["text"])  # envelope wraps; raw text preserved
         self.assertNotIn("resultType", result)
         self.assertNotIn("structuredContent", result)
 
@@ -3271,7 +3275,7 @@ class FleetControlsTest(unittest.TestCase):
         first, err1 = bm.handle_call("sre_error_rate", {})
         second, err2 = bm.handle_call("sre_error_rate", {})
         self.assertFalse(err1 or err2)
-        self.assertEqual(first, "result")
+        self.assertIn("result", first)  # envelope wraps raw output; raw text is preserved
         self.assertIn("cached", second)
         self.assertEqual(len(self.calls), 1)
 
@@ -4858,6 +4862,129 @@ class SavedQueryProjectionTest(unittest.TestCase):
         finally:
             bm._TRANSPORT = orig_transport
             bm.send = orig_send
+
+
+class ResultEnvelopeTest(unittest.TestCase):
+    """FR-1 through FR-4: result envelope for the SIMPLE fixed-query path."""
+
+    def setUp(self):
+        self._next_return = ("col_a\nrow1\nrow2", False)
+
+        def fake_run_bzrk(args, timeout=bm.DEFAULT_TIMEOUT):
+            self.calls.append(list(args))
+            return self._next_return
+
+        self.calls = []
+        self._orig_run = bm.run_bzrk
+        bm.run_bzrk = fake_run_bzrk
+
+        self._orig_cache_ttl = bm.CACHE_TTL_SECONDS
+        bm.CACHE_TTL_SECONDS = 0
+        bm._RESULT_CACHE.clear()
+        bm._FAIL_COOLDOWN.clear()
+
+        self._orig_envelope = bm.ENVELOPE_ENABLED
+        bm.ENVELOPE_ENABLED = True
+
+    def tearDown(self):
+        bm.run_bzrk = self._orig_run
+        bm.CACHE_TTL_SECONDS = self._orig_cache_ttl
+        bm._RESULT_CACHE.clear()
+        bm._FAIL_COOLDOWN.clear()
+        bm.ENVELOPE_ENABLED = self._orig_envelope
+
+    def test_01_rows_present_header_and_verbatim_body(self):
+        self._next_return = ("col_a\nrow1\nrow2", False)
+        text, err = bm.handle_call("list_hosts", {})
+        self.assertFalse(err)
+        self.assertTrue(text.startswith("window=1h ago  rows=2\n\n"))
+        self.assertTrue(text.endswith("col_a\nrow1\nrow2"))
+
+    def test_02_explicit_since_appears_in_header(self):
+        self._next_return = ("col_a\nrow1", False)
+        text, err = bm.handle_call("list_hosts", {"since": "6h ago"})
+        self.assertFalse(err)
+        self.assertTrue(text.startswith("window=6h ago  rows=1\n\n"))
+
+    def test_03_no_rows_returns_interpreted_sentence(self):
+        self._next_return = ("(no rows)", False)
+        text, err = bm.handle_call("list_hosts", {})
+        self.assertFalse(err)
+        self.assertIn("No rows in window 1h ago", text)
+        self.assertIn(bm._EMPTY_NEXT_STEP["list_hosts"][:20], text)
+
+    def test_04_every_simple_tool_has_next_step(self):
+        self.assertEqual(set(bm._EMPTY_NEXT_STEP), set(bm.SIMPLE))
+
+    def test_05_overflow_simple_returns_since_only_message(self):
+        overflow_msg = (
+            f"bzrk result exceeded BERSERK_MCP_MAX_RESULT_BYTES="
+            f"{bm.MAX_BZRK_RESULT_BYTES}; narrow the time window, project fewer "
+            "columns, or add a smaller take/top/tail bound."
+        )
+        self._next_return = (overflow_msg, True)
+        text, err = bm.handle_call("list_hosts", {})
+        self.assertTrue(err)
+        self.assertIn("fixed", text)
+        self.assertIn("since=", text)
+        self.assertNotIn("project fewer columns", text)
+        self.assertNotIn("take/top/tail", text)
+
+    def test_06_overflow_search_keeps_three_lever_message(self):
+        overflow_msg = (
+            f"bzrk result exceeded BERSERK_MCP_MAX_RESULT_BYTES="
+            f"{bm.MAX_BZRK_RESULT_BYTES}; narrow the time window, project fewer "
+            "columns, or add a smaller take/top/tail bound."
+        )
+        self._next_return = (overflow_msg, True)
+        text, err = bm.handle_call("search", {"kql": f"{bm.TABLE} | take 1"})
+        self.assertTrue(err)
+        self.assertIn("project fewer columns", text)
+        self.assertIn("take/top/tail", text)
+
+    def test_07_gate_off_restores_prior_output(self):
+        bm.ENVELOPE_ENABLED = False
+        self._next_return = ("col_a\nrow1\nrow2", False)
+        text, err = bm.handle_call("list_hosts", {})
+        self.assertFalse(err)
+        self.assertEqual(text, "col_a\nrow1\nrow2")
+        bm._RESULT_CACHE.clear()
+        self._next_return = ("(no rows)", False)
+        text, err = bm.handle_call("list_hosts", {"since": "30m ago"})
+        self.assertFalse(err)
+        self.assertEqual(text, "(no rows)")
+
+    def test_08_json_tool_gets_envelope_with_json_row_count(self):
+        kusto_json = (
+            '{"Tables":[{"schema":{"columns":[{"name":"svc","type":"string"}]},'
+            '"rows":[["svcA"],["svcB"]]}]}'
+        )
+        self._next_return = (kusto_json, False)
+        text, err = bm.handle_call("claude_errors", {})
+        self.assertFalse(err)
+        last_call = self.calls[-1]
+        self.assertIn("--json", last_call)
+        self.assertTrue(text.startswith("window=6h ago  rows=2\n\n"))
+        self.assertTrue(text.endswith(kusto_json))
+
+    def test_09_auth_failure_unenveloped(self):
+        self._next_return = (bm.AUTH_FAILURE_MESSAGE, True)
+        text, err = bm.handle_call("list_hosts", {})
+        self.assertTrue(err)
+        self.assertEqual(text, bm.AUTH_FAILURE_MESSAGE)
+
+    def test_10_envelope_never_raises_on_construction_failure(self):
+        class _RaisingDict:
+            def get(self, *args, **kwargs):
+                raise RuntimeError("injected failure")
+
+        orig = bm._EMPTY_NEXT_STEP
+        try:
+            bm._EMPTY_NEXT_STEP = _RaisingDict()
+            result = bm._envelope("list_hosts", "1h ago", "(no rows)")
+            self.assertEqual(result, "(no rows)")
+        finally:
+            bm._EMPTY_NEXT_STEP = orig
 
 
 if __name__ == "__main__":

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -378,7 +378,7 @@ class OutputFilterTest(unittest.TestCase):
     def test_off_mode_returns_output_unchanged(self):
         bm.REDACT_MODE = "off"
         text = self._call()
-        self.assertEqual(text, f"service body password=hunter2 {AWS_KEY}")
+        self.assertIn(f"service body password=hunter2 {AWS_KEY}", text)  # raw content preserved; envelope wraps it
 
 
 class SecretAuditMcpTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- **FR-1**: Added `_envelope(tool, since, out)` that prepends `window=... rows=...` to SIMPLE tool output. Row count is derived from output shape: table output counts non-header lines; JSON output uses `agent_analytics._json_records` (no invented parser).
- **FR-2**: Added `_EMPTY_NEXT_STEP` dict (one entry per all 24 SIMPLE tools) mapping `(no rows)` to a concrete next-step sentence naming the window. Confusable pairs (`top_cpu`↔`host_cpu`, `top_memory`↔`host_memory`) cross-reference each other.
- **FR-3**: SIMPLE-path overflow message now names `since` as the only lever; search overflow keeps all three suggestions unchanged.
- **FR-4**: `ENVELOPE_ENABLED = os.environ.get("BERSERK_MCP_ENVELOPE", "1")` gate; `"0"` restores byte-identical prior output. Documented in `.env.example` so `EnvExampleDriftTest` passes.

## Before / After

**`top_cpu` — empty result before:**
```
(no rows)
```

**`top_cpu` — empty result after:**
```
No rows in window 15m ago. For whole-machine CPU use host_cpu; top_cpu is per-container.
```

**`list_hosts` — populated result before:**
```
Host          Region
host-a        us-east-1
host-b        us-west-2
```

**`list_hosts` — populated result after:**
```
window=1h ago  rows=2

Host          Region
host-a        us-east-1
host-b        us-west-2
```

## Test plan

- [x] 10 new `ResultEnvelopeTest` cases covering all FR requirements
- [x] `test_04_every_simple_tool_has_next_step` asserts `set(_EMPTY_NEXT_STEP) == set(SIMPLE)` — a new tool cannot ship without a next step
- [x] 3 pre-existing test fixtures updated (all asserted raw output that the envelope now wraps)
- [x] Full suite: `python3 tests/test_berserk_mcp.py` → 362/362 pass
- [x] Gate-off: `BERSERK_MCP_ENVELOPE=0 python3 tests/test_berserk_mcp.py` → 362/362 pass
- [x] Protocol smoke: `python3 evals/mcp_protocol_smoke.py` → 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)