### PR TITLE
feat(eval): wire router eval into CI as a hard gate (#13, phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         run: python -m unittest discover -s tests
       - name: Run MCP protocol smoke from checkout
         run: python evals/mcp_protocol_smoke.py --include-http
+      - name: Run router eval CI gate unit tests
+        run: python evals/test_ci_gate.py
+      - name: Router eval CI gate (mock backend, no network/credentials)
+        run: python evals/ci_gate.py
       - name: Build the package
         run: |
           python -m pip install --upgrade pip build

--- a/evals/ci_gate.py
+++ b/evals/ci_gate.py
@@ -10,12 +10,13 @@ support), and the CI-critical pass/fail decision should not be entangled
 with that. This script only reads run_eval.py's saved JSON results file;
 it never imports or modifies run_eval.py.
 
-Threshold history: 65% set 2026-08-20 against the 41-case suite at that
-time (measured 65.85%). Ratchet up as evals/router_cases.jsonl grows
-more targeted phrasings (issue #13's own Phase 2, tracked as the same
-issue).
+Threshold history: 65% set 2026-08-20 against the router_cases.jsonl
+suite as it stood then (31 cases, mock backend measured 87.1%). Ratchet
+up as evals/router_cases.jsonl grows more targeted phrasings (issue #13's
+own Phase 2, tracked as the same issue).
 """
 import json
+import math
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +36,8 @@ def check_accuracy(results, min_accuracy=MIN_TOOL_ACCURACY):
     accuracy = results.get("tool_accuracy")
     if not isinstance(accuracy, (int, float)) or isinstance(accuracy, bool):
         return False, f"tool_accuracy missing or non-numeric in results: {accuracy!r}"
+    if not math.isfinite(accuracy) or not (0 <= accuracy <= 1):
+        return False, f"tool_accuracy out of the expected [0, 1] fraction range: {accuracy!r}"
     pct = accuracy * 100
     min_pct = min_accuracy * 100
     if accuracy < min_accuracy:

--- a/evals/ci_gate.py
+++ b/evals/ci_gate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""CI gate for the router eval harness (issue #13, Milestone 1's cheap
+half). Runs run_eval.py --backend mock against router_cases.jsonl and
+fails the build if tool-selection accuracy drops below the published
+threshold.
+
+Kept as a separate script from run_eval.py deliberately: run_eval.py is
+the harness itself (actively growing -- two-tier routing, real-backend
+support), and the CI-critical pass/fail decision should not be entangled
+with that. This script only reads run_eval.py's saved JSON results file;
+it never imports or modifies run_eval.py.
+
+Threshold history: 65% set 2026-08-20 against the 41-case suite at that
+time (measured 65.85%). Ratchet up as evals/router_cases.jsonl grows
+more targeted phrasings (issue #13's own Phase 2, tracked as the same
+issue).
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MIN_TOOL_ACCURACY = 0.65
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CASES_PATH = REPO_ROOT / "evals" / "router_cases.jsonl"
+RESULTS_DIR = REPO_ROOT / "evals" / "results"
+
+
+def check_accuracy(results, min_accuracy=MIN_TOOL_ACCURACY):
+    """Pure decision logic: (ok, message). Fails closed on anything that
+    isn't a plain numeric tool_accuracy field -- a malformed results
+    payload (e.g. run_eval.py changing its output schema) must not
+    silently pass a CI gate that exists specifically to catch regressions."""
+    accuracy = results.get("tool_accuracy")
+    if not isinstance(accuracy, (int, float)) or isinstance(accuracy, bool):
+        return False, f"tool_accuracy missing or non-numeric in results: {accuracy!r}"
+    pct = accuracy * 100
+    min_pct = min_accuracy * 100
+    if accuracy < min_accuracy:
+        return False, f"router eval regression: tool-selection accuracy {pct:.1f}% is below the {min_pct:.0f}% CI threshold"
+    return True, f"router eval OK: {pct:.1f}% >= {min_pct:.0f}% threshold"
+
+
+def _run_eval_and_load_results():
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    before = set(RESULTS_DIR.glob("mock_*.json"))
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "evals" / "run_eval.py"),
+         "--backend", "mock", str(CASES_PATH)],
+        capture_output=True, text=True, timeout=120,
+    )
+    print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result.returncode != 0:
+        sys.exit(f"run_eval.py exited {result.returncode}")
+    after = set(RESULTS_DIR.glob("mock_*.json"))
+    new_files = after - before
+    if not new_files:
+        sys.exit("run_eval.py did not produce a new results file")
+    results_path = max(new_files, key=lambda p: p.stat().st_mtime)
+    return json.loads(results_path.read_text(encoding="utf-8"))
+
+
+def main():
+    results = _run_eval_and_load_results()
+    ok, message = check_accuracy(results)
+    print(message)
+    if not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/test_ci_gate.py
+++ b/evals/test_ci_gate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Tests for evals/ci_gate.py's pure decision logic (issue #13). The
+subprocess-invocation/file-discovery glue mirrors this repo's existing
+convention (evals/mcp_protocol_smoke.py) of exercising integration scripts
+directly rather than unit-testing them; only the threshold comparison --
+the part a CI regression actually depends on being correct -- gets tests."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ci_gate  # noqa: E402
+
+
+class CheckAccuracyTest(unittest.TestCase):
+    def test_passes_at_exactly_the_threshold(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": 0.65}, min_accuracy=0.65)
+        self.assertTrue(ok, msg)
+
+    def test_passes_above_the_threshold(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": 0.90}, min_accuracy=0.65)
+        self.assertTrue(ok, msg)
+
+    def test_fails_below_the_threshold(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": 0.50}, min_accuracy=0.65)
+        self.assertFalse(ok)
+        self.assertIn("50", msg)
+        self.assertIn("65", msg)
+
+    def test_fails_closed_on_missing_field(self):
+        # A malformed or empty results payload must not silently pass --
+        # the whole point of a CI gate is to catch exactly this kind of
+        # thing (e.g. run_eval.py changing its output schema).
+        ok, msg = ci_gate.check_accuracy({}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+    def test_fails_closed_on_non_numeric_field(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": "not a number"}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/evals/test_ci_gate.py
+++ b/evals/test_ci_gate.py
@@ -38,6 +38,31 @@ class CheckAccuracyTest(unittest.TestCase):
         ok, msg = ci_gate.check_accuracy({"tool_accuracy": "not a number"}, min_accuracy=0.65)
         self.assertFalse(ok)
 
+    def test_fails_closed_on_nan(self):
+        # NaN compares false against everything, so a naive `accuracy <
+        # min_accuracy` check silently passes a NaN score -- exactly the
+        # kind of fail-open bug this gate exists to prevent.
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": float("nan")}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+    def test_fails_closed_on_positive_infinity(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": float("inf")}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+    def test_fails_closed_on_negative_infinity(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": float("-inf")}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+    def test_fails_closed_on_percentage_scaled_value(self):
+        # A results payload that reports 65.85 (meaning 65.85%) instead of
+        # 0.6585 must not slip through just because 65.85 < 0.65 is False.
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": 65.85}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
+    def test_fails_closed_on_negative_value(self):
+        ok, msg = ci_gate.check_accuracy({"tool_accuracy": -0.1}, min_accuracy=0.65)
+        self.assertFalse(ok)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds `evals/ci_gate.py`: runs `run_eval.py --backend mock` as a subprocess, reads its saved JSON results file, and fails the build if tool-selection accuracy drops below the published 65% threshold
- Adds `evals/test_ci_gate.py`: unit-tests the pure decision logic (`check_accuracy`); fails closed on missing/non-numeric `tool_accuracy`, and on non-finite or out-of-[0,1] values (NaN, Infinity, percentage-scaled numbers) so a malformed or misformatted results payload can't silently pass
- Threshold set to 65% against the router_cases.jsonl suite as it stood on 2026-08-20 (31 cases, mock backend measured 87.1%); ratchets up in #13 Phase 2

Deliberately did NOT modify `evals/run_eval.py` or `evals/router_cases.jsonl` — both have unrelated uncommitted/in-progress work in this working tree that isn't mine; `--backend mock` is purely additive.

## Test plan

- [x] `python evals/test_ci_gate.py` — unit tests pass (check_accuracy, fail-closed cases including NaN/Infinity/out-of-range)
- [x] `python evals/ci_gate.py` — gate passes at 87.1%
- [x] Verified gate fails correctly: forced `MIN_TOOL_ACCURACY=0.99`, confirmed exit 1
- [x] Full suite (715 tests) + protocol smoke test pass
- [x] CI green on all 6 matrix jobs
- [x] Independent Codex review — one P2 (fail-open gap on NaN/Infinity/out-of-range) fixed; one P3 doc-only nit (stale case-count claim) fixed in this same update

Closes #13 (phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)