### PR TITLE
feat: OpenRouter webhook receiver for eval telemetry

### DIFF
--- a/evals/openrouter_webhook_receiver.py
+++ b/evals/openrouter_webhook_receiver.py
@@ -107,6 +107,13 @@ def verify_signature(headers, expected_secret):
     return False
 
 
+def _provided_signature(headers):
+    for key, value in headers.items():
+        if key.lower() == "x-webhook-signature":
+            return value
+    return None
+
+
 def _make_handler(out_path, raw_out_path, expected_secret, lock):
     class Handler(BaseHTTPRequestHandler):
         def log_message(self, fmt, *args):
@@ -116,6 +123,14 @@ def _make_handler(out_path, raw_out_path, expected_secret, lock):
             headers = {k: v for k, v in self.headers.items()}
             length = int(self.headers.get("Content-Length", "0") or "0")
             body = self.rfile.read(length) if length else b""
+
+            # A *wrong* signature is always rejected, even on the test-connection
+            # handshake -- only a genuinely absent header gets the handshake's
+            # documented no-auth-required treatment.
+            provided_sig = _provided_signature(headers)
+            if provided_sig is not None and provided_sig != expected_secret:
+                self._respond(401, {"ok": False, "error": "signature mismatch"})
+                return
 
             if is_test_connection(headers):
                 self._respond(200, {"ok": True, "test_connection": True})
@@ -182,15 +197,33 @@ def main(argv=None):
         default="OPENROUTER_WEBHOOK_SECRET",
         help="env var holding the shared secret; must match the X-Webhook-Signature header value configured in OpenRouter's webhook UI",
     )
+    parser.add_argument(
+        "--secret-file",
+        default=None,
+        help="path to a file containing the shared secret (trailing newline stripped); "
+        "takes precedence over --secret-env if both resolve to a value. Prefer this over "
+        "an inline env assignment on the command line -- that form leaks the secret into "
+        "argv, visible to anyone on the host via ps/pgrep.",
+    )
     args = parser.parse_args(argv)
 
-    secret = os.environ.get(args.secret_env)
+    secret = None
+    if args.secret_file:
+        try:
+            with open(args.secret_file) as f:
+                secret = f.read().strip()
+        except OSError as exc:
+            sys.stderr.write(f"refusing to start: could not read --secret-file {args.secret_file}: {exc}\n")
+            sys.exit(1)
+    if not secret:
+        secret = os.environ.get(args.secret_env)
+
     if not secret:
         sys.stderr.write(
-            f"refusing to start: {args.secret_env} is not set. This server is meant to sit behind a "
-            "publicly reachable Tailscale Funnel URL, so it must not accept unauthenticated requests. "
-            f"Set {args.secret_env} to the same value configured as the X-Webhook-Signature header in "
-            "OpenRouter's webhook destination settings, then retry.\n"
+            f"refusing to start: neither --secret-file nor ${args.secret_env} provided a secret. This "
+            "server is meant to sit behind a publicly reachable Tailscale Funnel URL, so it must not "
+            "accept unauthenticated requests. Provide the same value configured as the X-Webhook-Signature "
+            "header in OpenRouter's webhook destination settings, then retry.\n"
         )
         sys.exit(1)
 

--- a/evals/openrouter_webhook_receiver.py
+++ b/evals/openrouter_webhook_receiver.py
@@ -1,0 +1,201 @@
+"""Minimal receiver for OpenRouter's Observability -> Broadcast webhook.
+
+Captures per-call token usage/cost telemetry (OTLP/JSON spans with GenAI
+semantic-convention attributes) that OpenRouter pushes out-of-band, as a
+passive complement to issue #37's in-harness cost computation. Every raw
+payload is preserved as received; parsed rows are a best-effort flattening
+of the fields OpenRouter documents (gen_ai.request.model,
+gen_ai.usage.prompt_tokens, gen_ai.usage.completion_tokens, user/session
+ids). Unrecognized attributes are kept under "attributes" rather than
+dropped, since the exact attribute set isn't contractually fixed.
+
+This binds to 0.0.0.0 and is meant to sit behind a Tailscale Funnel URL
+reachable from OpenRouter's cloud. A shared secret (checked against the
+X-Webhook-Signature header you configure in OpenRouter's webhook UI) is
+mandatory at startup -- there is no unauthenticated fallback.
+"""
+
+import argparse
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+_KNOWN_ATTR_KEYS = {
+    "gen_ai.request.model": "model",
+    "gen_ai.usage.prompt_tokens": "prompt_tokens",
+    "gen_ai.usage.completion_tokens": "completion_tokens",
+    "user.id": "user_id",
+    "session.id": "session_id",
+}
+
+_TOKEN_FIELDS = {"prompt_tokens", "completion_tokens"}
+
+
+def _unwrap_otlp_value(value):
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "intValue" in value:
+        return int(value["intValue"])
+    if "doubleValue" in value:
+        return value["doubleValue"]
+    if "boolValue" in value:
+        return value["boolValue"]
+    if "arrayValue" in value:
+        return [_unwrap_otlp_value(v) for v in value["arrayValue"].get("values", [])]
+    return None
+
+
+def _attrs_to_dict(attribute_list):
+    out = {}
+    for attr in attribute_list or []:
+        key = attr.get("key")
+        if key is None:
+            continue
+        out[key] = _unwrap_otlp_value(attr.get("value", {}))
+    return out
+
+
+def extract_spans(payload):
+    """Flatten an OTLP/JSON resourceSpans payload into one dict per span."""
+    rows = []
+    for resource_span in payload.get("resourceSpans") or []:
+        resource_attrs = _attrs_to_dict(
+            (resource_span.get("resource") or {}).get("attributes")
+        )
+        service_name = resource_attrs.get("service.name")
+        for scope_span in resource_span.get("scopeSpans") or []:
+            for span in scope_span.get("spans") or []:
+                span_attrs = _attrs_to_dict(span.get("attributes"))
+                row = {
+                    "trace_id": span.get("traceId"),
+                    "span_id": span.get("spanId"),
+                    "name": span.get("name"),
+                    "start_time_unix_nano": span.get("startTimeUnixNano"),
+                    "end_time_unix_nano": span.get("endTimeUnixNano"),
+                    "service_name": service_name,
+                }
+                catchall = {}
+                for otlp_key, value in span_attrs.items():
+                    field = _KNOWN_ATTR_KEYS.get(otlp_key)
+                    if field:
+                        row[field] = int(value) if field in _TOKEN_FIELDS and value is not None else value
+                    else:
+                        catchall[otlp_key] = value
+                for field in _KNOWN_ATTR_KEYS.values():
+                    row.setdefault(field, None)
+                row["attributes"] = catchall
+                rows.append(row)
+    return rows
+
+
+def is_test_connection(headers):
+    for key, value in headers.items():
+        if key.lower() == "x-test-connection":
+            return str(value).strip().lower() == "true"
+    return False
+
+
+def verify_signature(headers, expected_secret):
+    if not expected_secret:
+        return True
+    for key, value in headers.items():
+        if key.lower() == "x-webhook-signature":
+            return value == expected_secret
+    return False
+
+
+def _make_handler(out_path, raw_out_path, expected_secret, lock):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):
+            sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+        def do_POST(self):
+            headers = {k: v for k, v in self.headers.items()}
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            body = self.rfile.read(length) if length else b""
+
+            if is_test_connection(headers):
+                self._respond(200, {"ok": True, "test_connection": True})
+                return
+
+            if not verify_signature(headers, expected_secret):
+                self._respond(401, {"ok": False, "error": "signature mismatch"})
+                return
+
+            received_at = datetime.now(timezone.utc).isoformat()
+
+            with lock:
+                if raw_out_path:
+                    with open(raw_out_path, "a") as f:
+                        f.write(json.dumps({"received_at": received_at, "raw": body.decode("utf-8", "replace")}) + "\n")
+
+            try:
+                payload = json.loads(body) if body else {}
+            except ValueError as exc:
+                sys.stderr.write(f"failed to parse webhook payload as JSON: {exc}\n")
+                self._respond(200, {"ok": True, "parsed": False})
+                return
+
+            rows = extract_spans(payload)
+            with lock:
+                with open(out_path, "a") as f:
+                    for row in rows:
+                        row["received_at"] = received_at
+                        f.write(json.dumps(row) + "\n")
+
+            self._respond(200, {"ok": True, "spans_received": len(rows)})
+
+        def _respond(self, code, body_dict):
+            payload = json.dumps(body_dict).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    return Handler
+
+
+def run_server(port, out_path, raw_out_path, expected_secret):
+    lock = threading.Lock()
+    handler = _make_handler(out_path, raw_out_path, expected_secret, lock)
+    server = ThreadingHTTPServer(("0.0.0.0", port), handler)
+    print(f"listening on :{port} -> rows: {out_path}" + (f" raw: {raw_out_path}" if raw_out_path else ""))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--out", default="evals/results/openrouter_webhook_spans.jsonl")
+    parser.add_argument("--raw-out", default="evals/results/openrouter_webhook_raw.jsonl")
+    parser.add_argument(
+        "--secret-env",
+        default="OPENROUTER_WEBHOOK_SECRET",
+        help="env var holding the shared secret; must match the X-Webhook-Signature header value configured in OpenRouter's webhook UI",
+    )
+    args = parser.parse_args(argv)
+
+    secret = os.environ.get(args.secret_env)
+    if not secret:
+        sys.stderr.write(
+            f"refusing to start: {args.secret_env} is not set. This server is meant to sit behind a "
+            "publicly reachable Tailscale Funnel URL, so it must not accept unauthenticated requests. "
+            f"Set {args.secret_env} to the same value configured as the X-Webhook-Signature header in "
+            "OpenRouter's webhook destination settings, then retry.\n"
+        )
+        sys.exit(1)
+
+    run_server(args.port, args.out, args.raw_out, secret)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/openrouter_webhook_receiver.py
+++ b/evals/openrouter_webhook_receiver.py
@@ -25,8 +25,12 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 _KNOWN_ATTR_KEYS = {
     "gen_ai.request.model": "model",
-    "gen_ai.usage.prompt_tokens": "prompt_tokens",
-    "gen_ai.usage.completion_tokens": "completion_tokens",
+    # OpenRouter's actual wire format uses input_tokens/output_tokens, not the
+    # prompt_tokens/completion_tokens names its own docs page describes --
+    # confirmed against a real captured trace on 2026-08-22.
+    "gen_ai.usage.input_tokens": "prompt_tokens",
+    "gen_ai.usage.output_tokens": "completion_tokens",
+    "gen_ai.usage.total_cost": "cost_usd",
     "user.id": "user_id",
     "session.id": "session_id",
 }

--- a/evals/test_openrouter_webhook_receiver.py
+++ b/evals/test_openrouter_webhook_receiver.py
@@ -1,10 +1,17 @@
+import json
+import os
+import tempfile
+import threading
 import unittest
+from http.client import HTTPConnection
 
 from openrouter_webhook_receiver import (
+    _make_handler,
     extract_spans,
     is_test_connection,
     verify_signature,
 )
+from http.server import ThreadingHTTPServer
 
 
 def _attr(key, value):
@@ -150,6 +157,68 @@ class VerifySignatureTest(unittest.TestCase):
     def test_header_lookup_is_case_insensitive(self):
         headers = {"x-webhook-signature": "s3cr3t"}
         self.assertTrue(verify_signature(headers, "s3cr3t"))
+
+
+class HandlerIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.out_path = os.path.join(self.tmpdir, "spans.jsonl")
+        self.raw_path = os.path.join(self.tmpdir, "raw.jsonl")
+        handler = _make_handler(self.out_path, self.raw_path, "correct-secret", threading.Lock())
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.port = self.server.server_port
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def _post(self, headers, body=b""):
+        conn = HTTPConnection("127.0.0.1", self.port, timeout=5)
+        conn.request("POST", "/", body=body, headers=headers)
+        resp = conn.getresponse()
+        status = resp.status
+        resp.read()
+        conn.close()
+        return status
+
+    def test_test_connection_with_no_signature_header_succeeds(self):
+        self.assertEqual(self._post({"X-Test-Connection": "true"}), 200)
+
+    def test_test_connection_with_correct_signature_succeeds(self):
+        self.assertEqual(
+            self._post({"X-Test-Connection": "true", "X-Webhook-Signature": "correct-secret"}), 200
+        )
+
+    def test_test_connection_with_wrong_signature_is_rejected(self):
+        self.assertEqual(
+            self._post({"X-Test-Connection": "true", "X-Webhook-Signature": "wrong"}), 401
+        )
+
+    def test_real_payload_with_correct_signature_succeeds_and_is_recorded(self):
+        payload = json.dumps(_sample_payload()).encode()
+        status = self._post(
+            {"X-Webhook-Signature": "correct-secret", "Content-Type": "application/json"}, body=payload
+        )
+        self.assertEqual(status, 200)
+        with open(self.out_path) as f:
+            rows = [json.loads(line) for line in f]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["model"], "openai/gpt-4")
+
+    def test_real_payload_with_wrong_signature_is_rejected_and_not_recorded(self):
+        payload = json.dumps(_sample_payload()).encode()
+        status = self._post(
+            {"X-Webhook-Signature": "wrong", "Content-Type": "application/json"}, body=payload
+        )
+        self.assertEqual(status, 401)
+        self.assertFalse(os.path.exists(self.out_path))
+
+    def test_real_payload_with_no_signature_is_rejected(self):
+        payload = json.dumps(_sample_payload()).encode()
+        status = self._post({"Content-Type": "application/json"}, body=payload)
+        self.assertEqual(status, 401)
 
 
 if __name__ == "__main__":

--- a/evals/test_openrouter_webhook_receiver.py
+++ b/evals/test_openrouter_webhook_receiver.py
@@ -42,8 +42,9 @@ def _sample_payload():
                                 "endTimeUnixNano": "1700000000500000000",
                                 "attributes": [
                                     _attr("gen_ai.request.model", "openai/gpt-4"),
-                                    _attr("gen_ai.usage.prompt_tokens", 100),
-                                    _attr("gen_ai.usage.completion_tokens", 50),
+                                    _attr("gen_ai.usage.input_tokens", 100),
+                                    _attr("gen_ai.usage.output_tokens", 50),
+                                    _attr("gen_ai.usage.total_cost", 0.02),
                                     _attr("user.id", "u-1"),
                                     _attr("session.id", "s-1"),
                                     _attr("trace.metadata.case_id", "router-07"),
@@ -68,6 +69,7 @@ class ExtractSpansTest(unittest.TestCase):
         self.assertEqual(row["model"], "openai/gpt-4")
         self.assertEqual(row["prompt_tokens"], 100)
         self.assertEqual(row["completion_tokens"], 50)
+        self.assertEqual(row["cost_usd"], 0.02)
         self.assertEqual(row["user_id"], "u-1")
         self.assertEqual(row["session_id"], "s-1")
         self.assertEqual(row["service_name"], "openrouter")

--- a/evals/test_openrouter_webhook_receiver.py
+++ b/evals/test_openrouter_webhook_receiver.py
@@ -1,0 +1,156 @@
+import unittest
+
+from openrouter_webhook_receiver import (
+    extract_spans,
+    is_test_connection,
+    verify_signature,
+)
+
+
+def _attr(key, value):
+    if isinstance(value, bool):
+        return {"key": key, "value": {"boolValue": value}}
+    if isinstance(value, int):
+        return {"key": key, "value": {"intValue": str(value)}}
+    if isinstance(value, float):
+        return {"key": key, "value": {"doubleValue": value}}
+    return {"key": key, "value": {"stringValue": str(value)}}
+
+
+def _sample_payload():
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [_attr("service.name", "openrouter")]
+                },
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": "trace-1",
+                                "spanId": "span-1",
+                                "name": "chat.completions",
+                                "startTimeUnixNano": "1700000000000000000",
+                                "endTimeUnixNano": "1700000000500000000",
+                                "attributes": [
+                                    _attr("gen_ai.request.model", "openai/gpt-4"),
+                                    _attr("gen_ai.usage.prompt_tokens", 100),
+                                    _attr("gen_ai.usage.completion_tokens", 50),
+                                    _attr("user.id", "u-1"),
+                                    _attr("session.id", "s-1"),
+                                    _attr("trace.metadata.case_id", "router-07"),
+                                ],
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+class ExtractSpansTest(unittest.TestCase):
+    def test_flattens_known_gen_ai_fields(self):
+        rows = extract_spans(_sample_payload())
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["trace_id"], "trace-1")
+        self.assertEqual(row["span_id"], "span-1")
+        self.assertEqual(row["name"], "chat.completions")
+        self.assertEqual(row["model"], "openai/gpt-4")
+        self.assertEqual(row["prompt_tokens"], 100)
+        self.assertEqual(row["completion_tokens"], 50)
+        self.assertEqual(row["user_id"], "u-1")
+        self.assertEqual(row["session_id"], "s-1")
+        self.assertEqual(row["service_name"], "openrouter")
+
+    def test_keeps_unrecognized_attributes_in_catchall(self):
+        rows = extract_spans(_sample_payload())
+        self.assertEqual(
+            rows[0]["attributes"]["trace.metadata.case_id"], "router-07"
+        )
+
+    def test_numeric_token_attributes_are_ints_not_strings(self):
+        rows = extract_spans(_sample_payload())
+        self.assertIsInstance(rows[0]["prompt_tokens"], int)
+        self.assertIsInstance(rows[0]["completion_tokens"], int)
+
+    def test_empty_resource_spans_yields_no_rows(self):
+        self.assertEqual(extract_spans({"resourceSpans": []}), [])
+
+    def test_missing_resource_spans_key_yields_no_rows(self):
+        self.assertEqual(extract_spans({}), [])
+
+    def test_multiple_spans_across_multiple_resource_and_scope_levels(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": [_attr("service.name", "svc-a")]},
+                    "scopeSpans": [
+                        {"spans": [{"traceId": "t1", "spanId": "s1", "name": "n1", "attributes": []}]},
+                        {"spans": [{"traceId": "t2", "spanId": "s2", "name": "n2", "attributes": []}]},
+                    ],
+                },
+                {
+                    "resource": {"attributes": [_attr("service.name", "svc-b")]},
+                    "scopeSpans": [
+                        {"spans": [{"traceId": "t3", "spanId": "s3", "name": "n3", "attributes": []}]},
+                    ],
+                },
+            ]
+        }
+        rows = extract_spans(payload)
+        self.assertEqual([r["span_id"] for r in rows], ["s1", "s2", "s3"])
+        self.assertEqual([r["service_name"] for r in rows], ["svc-a", "svc-a", "svc-b"])
+
+    def test_span_missing_gen_ai_attributes_has_none_fields_not_a_crash(self):
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": []},
+                    "scopeSpans": [{"spans": [{"traceId": "t", "spanId": "s", "name": "n", "attributes": []}]}],
+                }
+            ]
+        }
+        row = extract_spans(payload)[0]
+        self.assertIsNone(row["model"])
+        self.assertIsNone(row["prompt_tokens"])
+        self.assertIsNone(row["completion_tokens"])
+
+
+class IsTestConnectionTest(unittest.TestCase):
+    def test_true_value_case_insensitive_header_name(self):
+        self.assertTrue(is_test_connection({"X-Test-Connection": "true"}))
+        self.assertTrue(is_test_connection({"x-test-connection": "true"}))
+
+    def test_absent_header_is_false(self):
+        self.assertFalse(is_test_connection({"Content-Type": "application/json"}))
+
+    def test_false_string_value_is_false(self):
+        self.assertFalse(is_test_connection({"X-Test-Connection": "false"}))
+
+
+class VerifySignatureTest(unittest.TestCase):
+    def test_no_secret_configured_always_passes(self):
+        self.assertTrue(verify_signature({}, None))
+        self.assertTrue(verify_signature({"X-Webhook-Signature": "anything"}, None))
+
+    def test_matching_secret_passes(self):
+        headers = {"X-Webhook-Signature": "s3cr3t"}
+        self.assertTrue(verify_signature(headers, "s3cr3t"))
+
+    def test_mismatched_secret_fails(self):
+        headers = {"X-Webhook-Signature": "wrong"}
+        self.assertFalse(verify_signature(headers, "s3cr3t"))
+
+    def test_missing_header_fails_when_secret_configured(self):
+        self.assertFalse(verify_signature({}, "s3cr3t"))
+
+    def test_header_lookup_is_case_insensitive(self):
+        headers = {"x-webhook-signature": "s3cr3t"}
+        self.assertTrue(verify_signature(headers, "s3cr3t"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #39.

Standalone stdlib-only receiver for OpenRouter's Observability -> Broadcast webhook. Captures authoritative per-call token usage (`gen_ai.usage.prompt_tokens`/`completion_tokens`, `gen_ai.request.model`) straight from OpenRouter's own OTLP/JSON traces, as a passive complement to #37's in-harness cost computation.

- Refuses to start without `OPENROUTER_WEBHOOK_SECRET` set — no unauthenticated fallback, since it's meant to sit behind a public Tailscale Funnel URL.
- Handles the `X-Test-Connection: true` handshake OpenRouter uses when validating a new webhook destination.
- Parses `resourceSpans` -> flattened per-span JSONL rows; unrecognized attributes preserved under `attributes` rather than dropped, since the field set isn't contractually fixed.
- 15 unit tests on the parsing/auth logic, all passing.

## Verification

No Codex/CI available this session (usage limit / Actions minutes exhausted, same as #26/#33/#34/#35/#38) — verified locally:
- `python3 -m unittest test_openrouter_webhook_receiver` — 15/15 pass
- Live end-to-end smoke test: server refuses to boot without the secret; test-connection handshake returns 200; wrong signature returns 401; a real OTLP payload with correct signature returns 200 and produces the expected flattened row in the output JSONL.

## Test plan

- [ ] Reviewer: run `python3 -m unittest test_openrouter_webhook_receiver` in `evals/`
- [ ] Set `OPENROUTER_WEBHOOK_SECRET`, start the server, point OpenRouter's webhook destination test button at it via a real Funnel URL, confirm the handshake and a real trace both land correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)