### PR TITLE
feat: persist per-case token usage, real cost, and cache-hit data

### DIFF
--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -208,6 +208,41 @@ def call_mock(user, tools):
     return pick(), {}, 0.0, {}
 
 
+# ---------- usage/cost extraction ----------
+def usage_fields(usage):
+    """Extract the per-call fields worth persisting from a raw `usage` dict.
+    Token counts default to 0 -- an empty/missing usage means no tokens were
+    used (e.g. the mock backend). cost_usd/cached_tokens default to None --
+    their absence means "this backend doesn't report it", not "it was free"
+    or "nothing was cached"; a fabricated 0 there would be misleading."""
+    usage = usage or {}
+    prompt_tokens = usage.get("prompt_tokens", usage.get("input_tokens", 0)) or 0
+    completion_tokens = usage.get("completion_tokens", usage.get("output_tokens", 0)) or 0
+    cost_usd = usage.get("cost")
+    cached_tokens = (usage.get("prompt_tokens_details") or {}).get("cached_tokens")
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cost_usd": cost_usd,
+        "cached_tokens": cached_tokens,
+    }
+
+
+def aggregate_usage(rows):
+    """Sum per-row token/cost fields into the top-level report fields.
+    total_cost_usd is None (not 0) when no row reported a cost -- absence of
+    cost data must not be misread as a free run."""
+    total_input_tokens = sum(r.get("prompt_tokens", 0) or 0 for r in rows)
+    total_output_tokens = sum(r.get("completion_tokens", 0) or 0 for r in rows)
+    costs = [r.get("cost_usd") for r in rows if r.get("cost_usd") is not None]
+    total_cost_usd = sum(costs) if costs else None
+    return {
+        "total_input_tokens": total_input_tokens,
+        "total_output_tokens": total_output_tokens,
+        "total_cost_usd": total_cost_usd,
+    }
+
+
 # ---------- scoring ----------
 def score_case(case, tool_name, args):
     tool_ok = (tool_name == case["expect_tool"])
@@ -276,7 +311,7 @@ def main():
     print(f"{'case':<22}{'expected':<20}{'got':<20}{'tool':<6}{'arg':<5}{'ms':>7}")
     print("-" * 80)
 
-    rows, tool_hits, arg_hits, lat, in_tok, out_tok = [], 0, 0, [], 0, 0
+    rows, tool_hits, arg_hits, lat = [], 0, 0, []
     total = 0
     for case in cases:
         for _ in range(args_ns.repeats):
@@ -291,21 +326,23 @@ def main():
             tool_hits += tool_ok
             arg_hits += arg_ok
             lat.append(dt)
-            in_tok += usage.get("prompt_tokens", usage.get("input_tokens", 0)) or 0
-            out_tok += usage.get("completion_tokens", usage.get("output_tokens", 0)) or 0
             print(f"{case['id']:<22}{case['expect_tool']:<20}{str(name):<20}"
                   f"{'OK' if tool_ok else 'X':<6}{'OK' if arg_ok else '-':<5}{dt*1000:>7.0f}")
             rows.append({"id": case["id"], "expect": case["expect_tool"], "got": name,
-                         "tool_ok": tool_ok, "arg_ok": arg_ok, "args": cargs, "ms": round(dt*1000)})
+                         "tool_ok": tool_ok, "arg_ok": arg_ok, "args": cargs, "ms": round(dt*1000),
+                         **usage_fields(usage)})
 
+    agg = aggregate_usage(rows)
     print("-" * 80)
     print(f"tool-selection accuracy : {tool_hits}/{total} = {100*tool_hits/total:.0f}%")
     print(f"argument accuracy       : {arg_hits}/{total} = {100*arg_hits/total:.0f}%")
     if any(lat):
         print(f"latency median/p95      : {statistics.median(lat)*1000:.0f} ms / "
               f"{sorted(lat)[max(0,int(0.95*len(lat))-1)]*1000:.0f} ms")
-    if in_tok or out_tok:
-        print(f"tokens in/out           : {in_tok} / {out_tok}")
+    if agg["total_input_tokens"] or agg["total_output_tokens"]:
+        print(f"tokens in/out           : {agg['total_input_tokens']} / {agg['total_output_tokens']}")
+    if agg["total_cost_usd"] is not None:
+        print(f"total cost              : ${agg['total_cost_usd']:.4f}")
 
     outdir = HERE / "results"
     outdir.mkdir(exist_ok=True)
@@ -313,7 +350,7 @@ def main():
     safe = label.replace(":", "_").replace("/", "_")
     report = {"backend": backend, "model": args_ns.model, "repeats": args_ns.repeats,
               "tool_accuracy": tool_hits/total, "arg_accuracy": arg_hits/total,
-              "rows": rows}
+              **agg, "rows": rows}
     (outdir / f"{safe}-{stamp}.json").write_text(json.dumps(report, indent=2))
     print(f"\nsaved: evals/results/{safe}-{stamp}.json")
 

--- a/evals/test_run_eval_usage.py
+++ b/evals/test_run_eval_usage.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for evals/run_eval.py's usage/cost extraction (issue #37). Only the
+pure per-call and aggregate logic gets unit tests, matching this repo's
+existing convention (test_ci_gate.py) of not unit-testing the
+subprocess/network glue -- that's covered by mcp_protocol_smoke.py-style
+integration checks instead."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_eval  # noqa: E402
+
+
+class UsageFieldsTest(unittest.TestCase):
+    def test_empty_usage_gives_zero_tokens_and_null_cost(self):
+        f = run_eval.usage_fields({})
+        self.assertEqual(f["prompt_tokens"], 0)
+        self.assertEqual(f["completion_tokens"], 0)
+        self.assertIsNone(f["cost_usd"])
+        self.assertIsNone(f["cached_tokens"])
+
+    def test_none_usage_behaves_like_empty(self):
+        f = run_eval.usage_fields(None)
+        self.assertEqual(f["prompt_tokens"], 0)
+        self.assertEqual(f["completion_tokens"], 0)
+        self.assertIsNone(f["cost_usd"])
+        self.assertIsNone(f["cached_tokens"])
+
+    def test_openai_style_token_keys(self):
+        f = run_eval.usage_fields({"prompt_tokens": 27330, "completion_tokens": 12})
+        self.assertEqual(f["prompt_tokens"], 27330)
+        self.assertEqual(f["completion_tokens"], 12)
+
+    def test_anthropic_style_token_keys(self):
+        f = run_eval.usage_fields({"input_tokens": 500, "output_tokens": 30})
+        self.assertEqual(f["prompt_tokens"], 500)
+        self.assertEqual(f["completion_tokens"], 30)
+
+    def test_openai_keys_take_priority_over_anthropic_keys_when_both_present(self):
+        # A backend should never send both, but if it did, prefer the
+        # explicit key already used elsewhere in this file's fallback chain.
+        f = run_eval.usage_fields({"prompt_tokens": 10, "input_tokens": 999})
+        self.assertEqual(f["prompt_tokens"], 10)
+
+    def test_real_cost_field_is_extracted(self):
+        f = run_eval.usage_fields({"prompt_tokens": 100, "cost": 0.00056052})
+        self.assertEqual(f["cost_usd"], 0.00056052)
+
+    def test_cached_tokens_extracted_from_nested_prompt_tokens_details(self):
+        f = run_eval.usage_fields({
+            "prompt_tokens": 27327,
+            "prompt_tokens_details": {"cached_tokens": 27296},
+        })
+        self.assertEqual(f["cached_tokens"], 27296)
+
+    def test_missing_prompt_tokens_details_does_not_crash(self):
+        f = run_eval.usage_fields({"prompt_tokens": 100})
+        self.assertIsNone(f["cached_tokens"])
+
+    def test_partial_usage_defaults_missing_token_field_to_zero(self):
+        f = run_eval.usage_fields({"prompt_tokens": 50})
+        self.assertEqual(f["completion_tokens"], 0)
+
+
+class AggregateUsageTest(unittest.TestCase):
+    def test_empty_rows_gives_zero_tokens_and_null_cost(self):
+        agg = run_eval.aggregate_usage([])
+        self.assertEqual(agg["total_input_tokens"], 0)
+        self.assertEqual(agg["total_output_tokens"], 0)
+        self.assertIsNone(agg["total_cost_usd"])
+
+    def test_sums_tokens_and_cost_across_rows(self):
+        rows = [
+            {"prompt_tokens": 100, "completion_tokens": 10, "cost_usd": 0.001},
+            {"prompt_tokens": 200, "completion_tokens": 20, "cost_usd": 0.002},
+        ]
+        agg = run_eval.aggregate_usage(rows)
+        self.assertEqual(agg["total_input_tokens"], 300)
+        self.assertEqual(agg["total_output_tokens"], 30)
+        self.assertAlmostEqual(agg["total_cost_usd"], 0.003)
+
+    def test_no_row_reporting_cost_gives_null_not_zero(self):
+        # A backend that never reports cost (local/Anthropic-direct) must not
+        # be misread as "this run was free" -- null means "unknown", not $0.
+        rows = [
+            {"prompt_tokens": 100, "completion_tokens": 10, "cost_usd": None},
+            {"prompt_tokens": 200, "completion_tokens": 20, "cost_usd": None},
+        ]
+        agg = run_eval.aggregate_usage(rows)
+        self.assertIsNone(agg["total_cost_usd"])
+
+    def test_mixed_cost_reporting_sums_only_the_rows_that_have_it(self):
+        rows = [
+            {"prompt_tokens": 100, "completion_tokens": 10, "cost_usd": 0.005},
+            {"prompt_tokens": 200, "completion_tokens": 20, "cost_usd": None},
+        ]
+        agg = run_eval.aggregate_usage(rows)
+        self.assertAlmostEqual(agg["total_cost_usd"], 0.005)
+        self.assertEqual(agg["total_input_tokens"], 300)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #37.

Persists `prompt_tokens`/`completion_tokens`/`cost_usd`/`cached_tokens` per row and `total_input_tokens`/`total_output_tokens`/`total_cost_usd` at the report level in `evals/results/*.json` -- previously computed, printed, then discarded.

Revised scope (see issue for full context): the original plan called for fetching OpenRouter's pricing endpoint and computing cost ourselves. That would have been wrong -- verified directly that naive `tokens × sticker price` math is off by 5-10x once caching is in play. Fix instead reads the real `usage.cost` the API already returns per call. No pricing fetch/cache needed.

**Bonus finding surfaced by this work**: `tool_choice="required"` (this harness's own default for the `openai` backend) prevents the provider from caching the tool-schema prefix at all -- verified live, `cached_tokens=0` on every row with `required`, vs. 99%+ cache hits from the second call onward with `auto`. Not changed here (there's a real tradeoff -- `required` exists specifically to force a tool call instead of prose), but now visible in the saved data instead of silently invisible, which is exactly the point of this issue.

## Verification

No Codex/CI available this session -- verified locally:
- `python3 -m unittest test_run_eval_usage` -- 13/13 new tests pass
- `python3 -m unittest discover -s evals -p "test_*.py"` -- 23/23 pass, nothing broke
- Live-verified against real OpenRouter traffic (mock backend: null cost as required, not 0; deepseek-v4-flash: real cost/cache data lands correctly per row and matches the API's own numbers)

## Test plan

- [ ] Reviewer: run `python3 -m unittest test_run_eval_usage` in `evals/`
- [ ] Run a real eval (`--backend openai --tool-choice auto`) and confirm `cost_usd`/`cached_tokens` populate correctly in the saved JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)