### PR TITLE
feat: live Claude Code quota-window status (#43)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,17 @@
 # "claude.tokens_output".
 # BERSERK_MCP_TOKENS_OUT_ATTR=claude.tokens_output
 
+# macOS Keychain service name claude_quota_status reads Claude Code's own
+# OAuth token from, for the live quota-window check (issue #43). Default:
+# "Claude Code-credentials" (Claude Code's own service name).
+# BERSERK_MCP_QUOTA_KEYCHAIN_SERVICE=Claude Code-credentials
+
+# Anthropic account-usage endpoint claude_quota_status calls with that
+# token. Undocumented/internal, not part of the public API -- override
+# only if Anthropic publishes a stable replacement. Default:
+# "https://api.anthropic.com/api/oauth/usage".
+# BERSERK_MCP_QUOTA_ENDPOINT=https://api.anthropic.com/api/oauth/usage
+
 # Comma-separated directory names used to infer a project root when
 # attributing sessions to projects. Default: "src,tests,lib,pkg".
 # BERSERK_MCP_PROJECT_MARKERS=src,tests,lib,pkg

--- a/agent_analytics.py
+++ b/agent_analytics.py
@@ -693,6 +693,30 @@ def analyze_cost_daily(rows):
             "r2": None}
 
 
+def total_tokens_estimate(since="5h ago", _events=None):
+    """Sum tokens across every session in the window, reusing the same
+    exact/estimated accounting as claude_token_burn -- the log-derived
+    fallback source for quota_status.py (issue #43) when the live
+    Keychain+endpoint path is unavailable.
+
+    Returns (total_tokens, all_exact, is_err). total_tokens is None only
+    on a query error (is_err True); 0 with all_exact True means "no
+    sessions in this window", which is not an error."""
+    if _events is None:
+        text, is_err = _bzrk_search(_burn_events_query(), since)
+        if is_err:
+            return None, False, True
+        events = _parse_rows(text)
+    else:
+        events = _events
+    reports = analyze_token_burn_events(events)
+    if not reports:
+        return 0, True, False
+    total = sum(r["tokens"] for r in reports)
+    all_exact = all(r["token_source"] == "exact" for r in reports)
+    return total, all_exact, False
+
+
 def claude_token_burn(since="6h ago", _events=None):
     if _events is None:
         text, is_err = _bzrk_search(_burn_events_query(), since)

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -76,6 +76,7 @@ import ai_finops
 import ingestion_advisor
 import kql_validation
 import parser_factory
+import quota_status
 import schema_registry
 import secret_scan
 import tool_discovery
@@ -2241,6 +2242,7 @@ TOOLS = [
     {"name": "claude_loop_check", "roles": ["claude"], "description": "Claude Code loop detector. Heuristically flags sessions that repeat the same tool/target, retry errors, or oscillate between the same calls. Bodies are truncated; output is diagnostic, not raw transcript replay. Default 6h.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "claude_model_fit", "roles": ["claude"], "description": "Claude Code model-fit heuristic. Uses observed tool count, errors, duration, and loop signals to flag frontier models on trivial work or cheap models on complex/repetitive work. Not a billing statement. Default 6h.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "claude_token_burn", "roles": ["claude"], "description": "Claude Code token-burn analysis. Uses exact claude.tokens_input/output usage when present, falls back to a labeled body-length estimate per session, computes burn per distinct tool/file target, and joins high burn with loop signals. Default 6h.", "inputSchema": {"type": "object", "properties": _since()}},
+    {"name": "claude_quota_status", "roles": ["claude"], "description": "Live Claude Code quota-window check. Tries a real-time reading from Anthropic's own account usage endpoint first (macOS only, reads Claude Code's local Keychain credential — an undocumented endpoint, so treat exact fields as best-effort); falls back to a log-derived token estimate over the trailing window when the live path is unavailable for any reason. Does not require the ingestion daemon/forwarder to be running. 'since' only affects the fallback window, default 5h.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "claude_cost_report", "roles": ["claude"], "description": "Claude Code multi-day cost report: per-day token burn with exact/estimated labeling, per-model split, optional per-project attribution from file paths, and a burn-growing/flat/declining trend verdict. Default 7d.", "inputSchema": {"type": "object", "properties": dict({"group_by": {"type": "string", "enum": ["day", "model", "project"], "description": "Aggregation: by day (default), model, or inferred project."}}, **_since())}},
     {"name": "claude_session_deep_dive", "roles": ["claude"], "description": "Timeline drilldown for one Claude Code session: contiguous tool phases with error counts, activity gaps over 5 minutes, cumulative token burn (exact/estimated), and a loop verdict. Requires session_id (find them via claude_sessions).", "inputSchema": {"type": "object", "properties": dict({"session_id": {"type": "string", "maxLength": agent_analytics.MAX_SESSION_ID_CHARS, "description": "claude.session_id value"}}, **_since()), "required": ["session_id"]}},
     {"name": "claude_workflow_insights", "roles": ["claude"], "description": "Cross-session Claude Code workflow patterns: most common tool sequences, error hotspots by tool+target, and top-decile burn-per-target sessions. Use for 'how is my agent working overall?'. Default 7d.", "inputSchema": {"type": "object", "properties": _since()}},
@@ -2368,6 +2370,7 @@ TITLES = {
     "claude_loop_check": "Claude Code: Loop Check",
     "claude_model_fit": "Claude Code: Model Fit",
     "claude_token_burn": "Claude Code: Token Burn",
+    "claude_quota_status": "Claude Code: Quota Status",
     "claude_cost_report": "Claude Code: Cost Report",
     "claude_session_deep_dive": "Claude Code: Session Deep Dive",
     "claude_workflow_insights": "Claude Code: Workflow Insights",
@@ -3079,6 +3082,15 @@ def _handle_call_uncached(name, arguments):
                 f"'2d ago', or 'now'."
             ), True
         return _wrap_analytics(agent_analytics.claude_token_burn(since))
+    if name == "claude_quota_status":
+        since = arguments.get("since") or "5h ago"
+        if not valid_since(since):
+            return (
+                f"invalid 'since' value: {since!r}. Use forms like '15m ago', '1h ago', "
+                f"'2d ago', or 'now'."
+            ), True
+        result = quota_status.get_quota_status(since=since)
+        return quota_status.format_quota_status(result), False
     if name == "claude_cost_report":
         since = arguments.get("since") or "7d ago"
         if not valid_since(since):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ berserk-mcp = "berserk_mcp:main"
 berserk-claude = "ai_finops:launcher_main"
 
 [tool.setuptools]
-py-modules = ["berserk_mcp", "parser_factory", "agent_analytics", "ai_finops", "secret_scan", "ingestion_advisor", "kql_validation", "schema_registry", "_store", "_http", "tool_discovery"]
+py-modules = ["berserk_mcp", "parser_factory", "agent_analytics", "ai_finops", "secret_scan", "ingestion_advisor", "kql_validation", "schema_registry", "_store", "_http", "tool_discovery", "quota_status"]
 
 [tool.setuptools.data-files]
 "share/berserk-mcp" = ["ingestion_catalog.json", "pricing_catalog.json"]

--- a/quota_status.py
+++ b/quota_status.py
@@ -1,0 +1,165 @@
+"""Live quota-window status for Claude Code (issue #43).
+
+Two paths, always graceful -- this module must never raise out to its
+caller, and must never require a daemon or forwarder to be running:
+
+1. Live: read the OAuth token Claude Code itself stores in the macOS
+   Keychain, call Anthropic's usage endpoint with it. Precise and
+   real-time, macOS-only. This is an UNDOCUMENTED, internal endpoint, not
+   part of Anthropic's public API -- its response shape is NOT verified
+   against real output (permission to test against a live Keychain token
+   was denied by this environment's auto-mode classifier; see issue #43's
+   discussion). Every field access on the live response is therefore
+   defensive and optional -- never assume a key exists, never raise on an
+   unexpected shape.
+
+2. Fallback: sum tokens already ingested via existing OTel telemetry over
+   the trailing window (agent_analytics.total_tokens_estimate). Works
+   everywhere, needs no local Keychain access, and is always used when the
+   live path fails for any reason -- unreachable endpoint, no Keychain
+   entry, non-macOS, malformed response.
+
+The caller is always told which path produced the result via the "source"
+field: "live", "estimated", or "unavailable".
+"""
+import json
+import os
+import platform
+import subprocess
+import urllib.error
+import urllib.request
+
+import agent_analytics
+
+KEYCHAIN_SERVICE = os.environ.get("BERSERK_MCP_QUOTA_KEYCHAIN_SERVICE", "Claude Code-credentials")
+USAGE_ENDPOINT = os.environ.get("BERSERK_MCP_QUOTA_ENDPOINT", "https://api.anthropic.com/api/oauth/usage")
+_KEYCHAIN_TIMEOUT_S = 5
+_HTTP_TIMEOUT_S = 5
+
+# Fields optimistically extracted from the live endpoint if present. This
+# list is a best guess, not a verified contract -- see the module
+# docstring. Extend it once a real response is confirmed.
+_LIVE_FIELDS = (
+    "utilization", "five_hour_utilization", "seven_day_utilization",
+    "resets_at", "rate_limit_tier",
+)
+
+
+def _read_oauth_token(run=subprocess.run, platform_name=None):
+    """Returns the access token string from the macOS Keychain, or None on
+    any failure -- never raises. macOS only (the `security` CLI doesn't
+    exist elsewhere)."""
+    if (platform_name if platform_name is not None else platform.system()) != "Darwin":
+        return None
+    try:
+        result = run(
+            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+            capture_output=True, text=True, timeout=_KEYCHAIN_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        blob = json.loads(result.stdout)
+    except ValueError:
+        return None
+    oauth = blob.get("claudeAiOauth") if isinstance(blob, dict) else None
+    if not isinstance(oauth, dict):
+        return None
+    token = oauth.get("accessToken")
+    return token if isinstance(token, str) and token else None
+
+
+def _fetch_live_usage(token, opener=urllib.request.urlopen):
+    """Calls the (undocumented, unstable) usage endpoint. Returns the
+    parsed JSON dict, or None on ANY failure -- network error, non-200,
+    unexpected body shape. Never raises."""
+    req = urllib.request.Request(
+        USAGE_ENDPOINT,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with opener(req, timeout=_HTTP_TIMEOUT_S) as resp:
+            status = getattr(resp, "status", None)
+            if status is None and hasattr(resp, "getcode"):
+                status = resp.getcode()
+            if status != 200:
+                return None
+            body = resp.read()
+    except Exception:
+        # Defensive by design: the live endpoint is undocumented and
+        # unverified (see module docstring). Any failure here -- network,
+        # TLS, timeout, or something not yet seen -- must degrade to the
+        # log-derived fallback, never propagate.
+        return None
+    try:
+        data = json.loads(body)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _extract_live_fields(data):
+    """Best-effort extraction from an unverified response shape. Every
+    field is optional; returns a dict with whatever was present."""
+    out = {}
+    if not isinstance(data, dict):
+        return out
+    for key in _LIVE_FIELDS:
+        if key in data:
+            out[key] = data[key]
+    return out
+
+
+def get_quota_status(since="5h ago", run=subprocess.run, opener=urllib.request.urlopen,
+                      platform_name=None, _total_tokens_estimate=agent_analytics.total_tokens_estimate):
+    """Main entry point. Tries the live Keychain+endpoint path first;
+    falls back to log-derived estimation on ANY failure. Never raises,
+    never requires a daemon/forwarder to be running. Returns a dict with
+    at least {"source": "live"|"estimated"|"unavailable", "ok": bool}."""
+    token = _read_oauth_token(run=run, platform_name=platform_name)
+    if token:
+        live = _fetch_live_usage(token, opener=opener)
+        if live is not None:
+            return {"source": "live", "ok": True, **_extract_live_fields(live)}
+
+    total, all_exact, is_err = _total_tokens_estimate(since)
+    if is_err or total is None:
+        return {
+            "source": "unavailable", "ok": False,
+            "detail": "live endpoint unavailable and the telemetry query failed",
+        }
+    return {
+        "source": "estimated", "ok": True, "since": since,
+        "total_tokens": total, "all_exact": all_exact,
+    }
+
+
+def format_quota_status(result):
+    """Render get_quota_status()'s dict as the human-readable text every
+    other claude_* tool returns."""
+    source = result.get("source")
+    if source == "live":
+        fields = {k: v for k, v in result.items() if k not in ("source", "ok")}
+        if not fields:
+            return (
+                "Live quota status: endpoint reachable but returned no recognized "
+                "usage fields (unverified response shape -- see issue #43)."
+            )
+        lines = ["Live quota status (from Anthropic's account usage endpoint):"]
+        for k, v in fields.items():
+            lines.append(f"- {k}: {v}")
+        return "\n".join(lines)
+    if source == "estimated":
+        exact_note = "exact usage" if result.get("all_exact") else "includes body-length estimates for some sessions"
+        return (
+            f"Estimated quota usage over {result.get('since')} "
+            f"(log-derived, live endpoint unavailable -- {exact_note}): "
+            f"{result.get('total_tokens')} tokens.\n"
+            "This is a retrospective estimate from ingested telemetry, not a live account reading."
+        )
+    return (
+        "Quota status unavailable: the live endpoint could not be reached "
+        f"and the fallback telemetry query failed ({result.get('detail', 'unknown error')})."
+    )

--- a/tests/test_agent_analytics.py
+++ b/tests/test_agent_analytics.py
@@ -163,6 +163,42 @@ class AgentAnalyticsPureTest(unittest.TestCase):
         report = aa.analyze_token_burn_events([negative])[0]
         self.assertEqual(report["tokens"], 20)
 
+    def test_total_tokens_estimate_sums_across_sessions(self):
+        events = [
+            usage_row("s1", "2026-07-12T10:00:00Z", "Read", 100, 50),
+            usage_row("s2", "2026-07-12T10:05:00Z", "Edit", 200, 75),
+        ]
+        total, all_exact, is_err = aa.total_tokens_estimate(_events=events)
+        self.assertEqual(total, 425)
+        self.assertTrue(all_exact)
+        self.assertFalse(is_err)
+
+    def test_total_tokens_estimate_all_exact_false_when_any_session_estimated(self):
+        events = [
+            usage_row("exact", "2026-07-12T10:00:00Z", "Read", 100, 50),
+            row("estimated", "2026-07-12T10:05:00Z", "Edit", "x" * 40),
+        ]
+        total, all_exact, is_err = aa.total_tokens_estimate(_events=events)
+        self.assertEqual(total, 160)  # 150 exact + 10 estimated (40 chars / 4)
+        self.assertFalse(all_exact)
+        self.assertFalse(is_err)
+
+    def test_total_tokens_estimate_no_sessions_is_zero_not_error(self):
+        total, all_exact, is_err = aa.total_tokens_estimate(_events=[])
+        self.assertEqual(total, 0)
+        self.assertTrue(all_exact)
+        self.assertFalse(is_err)
+
+    def test_total_tokens_estimate_propagates_query_error(self):
+        orig_search = aa._bzrk_search
+        try:
+            aa._bzrk_search = lambda query, since: ("bzrk: connection refused", True)
+            total, all_exact, is_err = aa.total_tokens_estimate(since="5h ago")
+            self.assertIsNone(total)
+            self.assertTrue(is_err)
+        finally:
+            aa._bzrk_search = orig_search
+
     def test_parse_rows_accepts_json_array_and_wrapper(self):
         recs = [row("s1", "2026-07-12T10:00:00Z", "Edit", "a.py")]
         self.assertEqual(len(aa._parse_rows(json.dumps(recs))), 1)          # bare array
@@ -501,6 +537,36 @@ class AgentAnalyticsMcpTest(unittest.TestCase):
         self.assertIn("claude.tokens_input", self.calls[-1][3])
         self.assertIn("claude.tokens_output", self.calls[-1][3])
         self.assertNotIn("substring(tostring(body), 0, 80)", self.calls[-1][3])
+
+    def test_quota_status_tool_dispatches_via_quota_status_module(self):
+        # Rewired at the berserk_mcp import site (not quota_status's own
+        # internals) so this stays deterministic in CI and never touches a
+        # real macOS Keychain during test runs -- matches _RewiredAnalytics'
+        # rationale for agent_analytics.
+        orig = bm.quota_status.get_quota_status
+        try:
+            bm.quota_status.get_quota_status = lambda since: {
+                "source": "estimated", "ok": True, "since": since,
+                "total_tokens": 1234, "all_exact": True,
+            }
+            text, err = bm.handle_call("claude_quota_status", {})
+            self.assertFalse(err)
+            self.assertIn("1234", text)
+            self.assertIn("5h ago", text)
+        finally:
+            bm.quota_status.get_quota_status = orig
+
+    def test_quota_status_invalid_since_rejected_before_calling_out(self):
+        calls = []
+        orig = bm.quota_status.get_quota_status
+        try:
+            bm.quota_status.get_quota_status = lambda since: calls.append(since) or {}
+            text, err = bm.handle_call("claude_quota_status", {"since": "bad; nope"})
+            self.assertTrue(err)
+            self.assertIn("invalid 'since'", text)
+            self.assertEqual(calls, [])
+        finally:
+            bm.quota_status.get_quota_status = orig
 
     def test_burn_query_is_bounded_and_unordered(self):
         query = self.calls[-1][3] if self.calls else aa._burn_events_query()

--- a/tests/test_quota_status.py
+++ b/tests/test_quota_status.py
@@ -1,0 +1,184 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import agent_analytics as aa  # noqa: E402
+import quota_status as qs  # noqa: E402
+
+
+def fake_completed_process(returncode, stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class ReadOauthTokenTest(unittest.TestCase):
+    def test_returns_none_on_nonzero_returncode(self):
+        run = lambda *a, **k: fake_completed_process(1, "")
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_on_empty_stdout(self):
+        run = lambda *a, **k: fake_completed_process(0, "")
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_on_malformed_json(self):
+        run = lambda *a, **k: fake_completed_process(0, "not json")
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_when_claudeAiOauth_key_missing(self):
+        run = lambda *a, **k: fake_completed_process(0, json.dumps({"other": "shape"}))
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_when_claudeAiOauth_is_not_a_dict(self):
+        run = lambda *a, **k: fake_completed_process(0, json.dumps({"claudeAiOauth": "nope"}))
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_when_accessToken_missing_or_empty(self):
+        run = lambda *a, **k: fake_completed_process(
+            0, json.dumps({"claudeAiOauth": {"subscriptionType": "max"}}))
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+        run2 = lambda *a, **k: fake_completed_process(
+            0, json.dumps({"claudeAiOauth": {"accessToken": ""}}))
+        self.assertIsNone(qs._read_oauth_token(run=run2, platform_name="Darwin"))
+
+    def test_returns_token_on_well_formed_blob(self):
+        run = lambda *a, **k: fake_completed_process(
+            0, json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat-fake", "subscriptionType": "max"}}))
+        self.assertEqual(qs._read_oauth_token(run=run, platform_name="Darwin"), "sk-ant-oat-fake")
+
+    def test_skips_entirely_on_non_macos(self):
+        # The `security` CLI doesn't exist outside macOS -- never even try.
+        calls = []
+        def run(*a, **k):
+            calls.append(a)
+            return fake_completed_process(0, json.dumps({"claudeAiOauth": {"accessToken": "x"}}))
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Linux"))
+        self.assertEqual(calls, [])
+
+    def test_returns_none_on_subprocess_timeout(self):
+        def run(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="security", timeout=5)
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+    def test_returns_none_on_missing_security_binary(self):
+        def run(*a, **k):
+            raise FileNotFoundError("no such file")
+        self.assertIsNone(qs._read_oauth_token(run=run, platform_name="Darwin"))
+
+
+class _FakeResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class FetchLiveUsageTest(unittest.TestCase):
+    def test_returns_parsed_dict_on_200(self):
+        opener = lambda req, timeout: _FakeResponse(200, json.dumps({"a": 1}).encode())
+        self.assertEqual(qs._fetch_live_usage("tok", opener=opener), {"a": 1})
+
+    def test_returns_none_on_non_200_status(self):
+        opener = lambda req, timeout: _FakeResponse(403, b"{}")
+        self.assertIsNone(qs._fetch_live_usage("tok", opener=opener))
+
+    def test_returns_none_on_malformed_json_body(self):
+        opener = lambda req, timeout: _FakeResponse(200, b"not json")
+        self.assertIsNone(qs._fetch_live_usage("tok", opener=opener))
+
+    def test_returns_none_when_body_is_a_json_array_not_object(self):
+        opener = lambda req, timeout: _FakeResponse(200, b"[1,2,3]")
+        self.assertIsNone(qs._fetch_live_usage("tok", opener=opener))
+
+    def test_returns_none_on_connection_error(self):
+        def opener(req, timeout):
+            raise OSError("connection refused")
+        self.assertIsNone(qs._fetch_live_usage("tok", opener=opener))
+
+    def test_never_raises_on_completely_unexpected_exception_shape(self):
+        # Defensive: the live endpoint is undocumented and unverified: an
+        # unexpected error type here must still degrade to None, not crash
+        # the whole quota-status call.
+        def opener(req, timeout):
+            raise ValueError("surprise")
+        self.assertIsNone(qs._fetch_live_usage("tok", opener=opener))
+
+
+class GetQuotaStatusTest(unittest.TestCase):
+    def test_uses_live_path_when_token_and_endpoint_both_succeed(self):
+        run = lambda *a, **k: fake_completed_process(
+            0, json.dumps({"claudeAiOauth": {"accessToken": "tok"}}))
+        opener = lambda req, timeout: _FakeResponse(200, json.dumps({"five_hour_utilization": 42}).encode())
+        result = qs.get_quota_status(run=run, opener=opener, platform_name="Darwin")
+        self.assertEqual(result["source"], "live")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["five_hour_utilization"], 42)
+
+    def test_falls_back_to_estimate_when_no_token(self):
+        run = lambda *a, **k: fake_completed_process(1, "")  # keychain miss
+        result = qs.get_quota_status(
+            run=run, platform_name="Darwin",
+            _total_tokens_estimate=lambda since: (500, True, False),
+        )
+        self.assertEqual(result["source"], "estimated")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["total_tokens"], 500)
+        self.assertTrue(result["all_exact"])
+
+    def test_falls_back_to_estimate_when_live_endpoint_fails(self):
+        run = lambda *a, **k: fake_completed_process(
+            0, json.dumps({"claudeAiOauth": {"accessToken": "tok"}}))
+        opener = lambda req, timeout: _FakeResponse(500, b"{}")
+        result = qs.get_quota_status(
+            run=run, opener=opener, platform_name="Darwin",
+            _total_tokens_estimate=lambda since: (300, False, False),
+        )
+        self.assertEqual(result["source"], "estimated")
+        self.assertEqual(result["total_tokens"], 300)
+        self.assertFalse(result["all_exact"])
+
+    def test_reports_unavailable_when_both_paths_fail(self):
+        run = lambda *a, **k: fake_completed_process(1, "")
+        result = qs.get_quota_status(
+            run=run, platform_name="Darwin",
+            _total_tokens_estimate=lambda since: (None, False, True),
+        )
+        self.assertEqual(result["source"], "unavailable")
+        self.assertFalse(result["ok"])
+
+    def test_never_requires_a_daemon_or_forwarder_running(self):
+        # Sanity: get_quota_status must not import/touch anything that
+        # implies a running background process -- it only calls run/opener
+        # and (on fallback) the injected estimator.
+        run = lambda *a, **k: fake_completed_process(1, "")
+        result = qs.get_quota_status(
+            run=run, platform_name="Darwin",
+            _total_tokens_estimate=lambda since: (0, True, False),
+        )
+        self.assertIn(result["source"], {"estimated", "unavailable"})
+
+
+class QuotaStatusToolIntegrationTest(unittest.TestCase):
+    """Confirms total_tokens_estimate really is what the fallback wires to
+    by default (no injected estimator) -- catches drift between the two
+    modules without re-mocking agent_analytics internals here."""
+
+    def test_default_estimator_is_agent_analytics_total_tokens_estimate(self):
+        import inspect
+        sig = inspect.signature(qs.get_quota_status)
+        default = sig.parameters["_total_tokens_estimate"].default
+        self.assertIs(default, aa.total_tokens_estimate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -136,6 +136,7 @@ PHRASINGS = {
     "claude_loop_check": ["is claude stuck in a loop", "detect claude retry loops", "loop detector for claude"],
     "claude_model_fit": ["is claude using the wrong model size for the task", "model fit heuristic", "frontier model on trivial work"],
     "claude_token_burn": ["how many tokens is claude burning", "token burn analysis", "which session used the most tokens"],
+    "claude_quota_status": ["how much of my 5 hour quota is left", "live claude usage window check", "am I about to hit my rate limit"],
     "claude_cost_report": ["claude code cost report", "daily token cost breakdown", "cost per day for claude"],
     "claude_session_deep_dive": ["deep dive into one claude session", "timeline drilldown for a session", "inspect a single session in detail"],
     "claude_workflow_insights": ["claude workflow patterns", "common tool sequences", "cross session workflow analysis"],


### PR DESCRIPTION
## Summary
- New `claude_quota_status` tool: live read from Anthropic's account usage endpoint (macOS Keychain + the undocumented `/api/oauth/usage` endpoint), falling back to a log-derived token estimate over the trailing window when the live path fails for any reason.
- Never requires the ingestion daemon/forwarder to be running — this is meant to be a fast, standalone check, per the issue's scope.
- Live endpoint response shape is explicitly **unverified** — permission to test against a real macOS Keychain token was denied by this environment's auto-mode classifier during implementation (a correct block: reading Keychain credentials is a sensitive action). Every field access on the live response is therefore defensive/optional by design, not because of laziness — see the module docstring in `quota_status.py`. A future session with the right permissions should confirm the real response shape and tighten `_LIVE_FIELDS` accordingly.
- Adds `agent_analytics.total_tokens_estimate()` as the shared fallback data source, reusing `claude_token_burn`'s existing exact/estimated accounting rather than re-deriving it.

## Test plan
- [x] `python -m unittest discover -s tests` — 861 tests, all green (22 new for `quota_status.py`, 4 new for `agent_analytics.total_tokens_estimate` + dispatch)
- [x] `python evals/mcp_protocol_smoke.py --include-http` — all pass
- [x] Fresh-venv install (`pip install .`) confirms `quota_status` is actually packaged — this is the exact failure mode that broke CI on #52 (module present in checkout, missing from `pyproject.toml`'s `py-modules`)
- [x] `.env.example` and `tool_discovery` recall-gate drift tests both updated and passing

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)