### PR TITLE
fix: dry-run in openrouter_backfill_to_berserk.py must not persist state

### DIFF
--- a/evals/openrouter_backfill_to_berserk.py
+++ b/evals/openrouter_backfill_to_berserk.py
@@ -94,20 +94,25 @@ def run_backfill(raw_path, state_path, endpoint, batch_size=25, dry_run=False,
     total_spans = 0
 
     def flush():
+        # dry_run never calls _write_state, anywhere in this function --
+        # a preview run must be fully non-destructive to resume state, or
+        # a real run afterward would think this range is already done and
+        # silently skip it (caught by actually dry-running this script
+        # before a real backfill, not by reasoning about it in advance).
         nonlocal batch_payloads, batch_line_count, total_forwarded_lines, total_spans
         if not batch_payloads:
             return True
         merged = merge_payloads(batch_payloads)
         if merged is None:
             total_forwarded_lines += batch_line_count
-            _write_state(state_path, total_forwarded_lines)
+            if not dry_run:
+                _write_state(state_path, total_forwarded_lines)
             batch_payloads, batch_line_count = [], 0
             return True
         n_records = sum(len(rl["scopeLogs"][0]["logRecords"]) for rl in merged["resourceLogs"])
         if dry_run:
             print(f"[dry-run] would forward {n_records} span(s) across {batch_line_count} line(s)")
             total_forwarded_lines += batch_line_count
-            _write_state(state_path, total_forwarded_lines)
             batch_payloads, batch_line_count = [], 0
             return True
         ok, detail = post_fn(endpoint, merged)

--- a/evals/test_openrouter_backfill_to_berserk.py
+++ b/evals/test_openrouter_backfill_to_berserk.py
@@ -138,6 +138,21 @@ class RunBackfillTest(unittest.TestCase):
         ok = run_backfill(self.raw_path, self.state_path, "http://x/v1/logs",
                            batch_size=25, dry_run=True, post_fn=should_not_be_called)
         self.assertTrue(ok)
+
+    def test_dry_run_does_not_persist_state_a_real_run_afterward_still_sees_everything(self):
+        # Regression: an earlier version advanced and wrote the state file
+        # even in dry-run, so a real run right after a preview would think
+        # this range was already done and silently skip it -- caught by
+        # actually dry-running the deployed script before the real
+        # backfill, not by reasoning about it in advance.
+        self._write_raw(3)
+        run_backfill(self.raw_path, self.state_path, "http://x/v1/logs",
+                      batch_size=25, dry_run=True, post_fn=lambda *a, **k: (_ for _ in ()).throw(AssertionError))
+        self.assertEqual(_read_state(self.state_path), 0)
+        ok = run_backfill(self.raw_path, self.state_path, "http://x/v1/logs",
+                           batch_size=25, post_fn=self._fake_post)
+        self.assertTrue(ok)
+        self.assertEqual(len(self.posted[0]["resourceLogs"]), 3)
         self.assertEqual(_read_state(self.state_path), 3)
 
     def test_malformed_line_is_skipped_not_fatal(self):


### PR DESCRIPTION
## Summary
Found this by actually dry-running the merged script against the real 245-record capture on the beserk box before running it for real, not by reasoning about it. `--dry-run` was advancing and writing the resume-state file exactly as a real run would — so a real run immediately after a preview would see the whole range already marked forwarded and silently skip it. Nothing would actually reach Berserk, and there'd be no error to indicate that; the script would just print "done" and exit 0.

Fix: `_write_state` is now only called on the two real-forwarding-succeeded paths, never on the dry-run path.

## Test plan
- [x] New regression test: dry-run leaves state at 0, then a real run right after still sees and forwards everything
- [x] `python -m unittest discover -s tests` — 861 tests, all green
- [x] `evals/test_openrouter_backfill_to_berserk.py` — 15 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)