### PR TITLE
fix: _schema_fetcher no longer swallows run_bzrk errors (#32)

### DIFF
--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -1490,10 +1490,30 @@ def do_schema():
 
 
 def _schema_fetcher():
-    out_tables, _ = run_bzrk(["-P", PROFILE, "search", ".show tables"])
-    out_schema, _ = run_bzrk(["-P", PROFILE, "search", f"{T} | getschema", "--since", "1h ago"])
-    out_fields, _ = run_bzrk(["-P", PROFILE, "search", q_discover_fieldstats(None), "--since", "1h ago"])
-    out_sample, _ = run_bzrk(["-P", PROFILE, "search", q_discover_sample(None), "--since", "1h ago"])
+    """Fetch raw schema material for schema_registry.get_schema_snapshot().
+
+    Contract (schema_registry.py): the fetcher must raise on failure so the
+    caller's except-Exception falls back to a stale cache or reports
+    "unavailable" -- it must never return error text as if it were real
+    schema data, which would get normalized and cached as source_status
+    "fresh". Any of the four run_bzrk calls failing (auth error, timeout,
+    connection refused, etc.) fails the whole fetch, matching do_schema()'s
+    existing any-fails semantics just above -- a partial result would still
+    mean feeding one call's error text into normalize_snapshot as if it
+    were real tables/columns/fields/sample data.
+    """
+    out_tables, e_tables = run_bzrk(["-P", PROFILE, "search", ".show tables"])
+    out_schema, e_schema = run_bzrk(["-P", PROFILE, "search", f"{T} | getschema", "--since", "1h ago"])
+    out_fields, e_fields = run_bzrk(["-P", PROFILE, "search", q_discover_fieldstats(None), "--since", "1h ago"])
+    out_sample, e_sample = run_bzrk(["-P", PROFILE, "search", q_discover_sample(None), "--since", "1h ago"])
+    failed = [
+        name for name, is_err in (
+            ("tables", e_tables), ("getschema", e_schema),
+            ("fieldstats", e_fields), ("sample", e_sample),
+        ) if is_err
+    ]
+    if failed:
+        raise RuntimeError(f"schema fetch failed for: {', '.join(failed)}")
     return {
         "tables": out_tables,
         "getschema": out_schema,

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -5831,20 +5831,29 @@ class WrongAnswerContainmentTest(unittest.TestCase):
             bm._validate_user_kql = orig_validate
             bm.run_bzrk = orig_run_bzrk
 
-    def test_schema_drift_backend_unavailable_produces_false_positive_warning(self):
-        # Exercises the REAL production path (a prior version of this test
-        # stubbed _validate_user_kql directly, which skipped _schema_fetcher
+    def test_schema_fetch_backend_unavailable_is_reported_as_unavailable_not_fresh(self):
+        # Regression test for issue #32, fixed: exercises the REAL
+        # production path (a prior version of this test stubbed
+        # _validate_user_kql directly, which skipped _schema_fetcher
         # entirely and didn't match what actually happens -- caught in
-        # review). _schema_fetcher (:1271) calls run_bzrk() for its four
-        # schema-discovery queries and ignores the returned error flag, so a
-        # genuine backend failure (auth error, timeout, etc.) doesn't raise
-        # and doesn't produce schema_registry's "unavailable" status either
-        # -- get_schema_snapshot() has no way to know the fetch failed, so it
-        # normalizes whatever error text came back as if it were real schema
-        # output and marks the result "fresh". The resulting hash is some
-        # value derived from that error text, essentially unpredictable, so
-        # it does not equal any real previously-stored hash -- producing a
-        # false-positive drift warning.
+        # review). _schema_fetcher (:1492) calls run_bzrk() for its four
+        # schema-discovery queries; before the fix it ignored the returned
+        # error flag entirely, so a genuine backend failure (auth error,
+        # timeout, etc.) never raised and get_schema_snapshot() had no way
+        # to know the fetch failed -- it normalized whatever error text
+        # came back as if it were real schema output and marked the result
+        # "fresh". Now _schema_fetcher raises when any of the four calls
+        # fail, so get_schema_snapshot's except-Exception branch correctly
+        # falls back to "unavailable" (no prior cache in this test's fresh
+        # config_dir).
+        #
+        # The drift warning itself still fires here -- that's correct, not
+        # a regression: the stored hash is a fake value from "when the
+        # backend was healthy", and an "unavailable" snapshot still
+        # computes a real (if empty-schema-derived) current hash, which
+        # legitimately differs from the stored one. What changed is that
+        # the snapshot backing that comparison is now honestly labeled
+        # "unavailable" instead of falsely "fresh".
         #
         # All four of _schema_fetcher's calls fail (not just two), using the
         # real production auth-failure message. Only the saved query's own
@@ -5867,19 +5876,46 @@ class WrongAnswerContainmentTest(unittest.TestCase):
                  "schema_hash": "stored_hash_from_when_backend_was_healthy"},
                 action_source="manual",
             )
-            # Lock the actual mechanism, not just the final warning text:
-            # the snapshot backing this run is genuinely marked "fresh"
-            # (not "unavailable") despite every fetch call failing, and the
-            # warning's current= hash is exactly that snapshot's hash. If
-            # issue #32 is fixed (fetcher raises instead of swallowing the
-            # error), schema_status would become "unavailable"/"stale" and
-            # this assertion would correctly start failing.
             snapshot = bm._schema_snapshot(force=True, allow_refresh=True)
-            self.assertEqual(snapshot["source_status"], "fresh")
+            self.assertEqual(snapshot["source_status"], "unavailable")
             text, err = bm.handle_call("run_saved", {"name": "backend_unavailable_probe"})
             self.assertFalse(err)
             self.assertIn("Schema drift warning", text)
             self.assertIn(f"current={snapshot['schema_hash']}", text)
+        finally:
+            bm.run_bzrk = orig_run_bzrk
+
+    def test_schema_fetcher_raises_when_any_of_four_calls_fail(self):
+        # Direct unit test of the fetcher contract itself, independent of
+        # the drift-warning integration above: _schema_fetcher must raise
+        # (not return error text as data) as soon as any one of its four
+        # run_bzrk calls reports an error, even if the other three succeed.
+        # Mirrors do_schema()'s existing any-fails semantics just above it
+        # in berserk_mcp.py.
+        orig_run_bzrk = bm.run_bzrk
+        for failing_call_substring in (".show tables", "getschema", "fieldstats", "resource_keys=bag_keys"):
+            def make_run_bzrk(fail_on):
+                def _run(args, timeout=bm.DEFAULT_TIMEOUT):
+                    joined = " ".join(str(a) for a in args)
+                    if fail_on in joined:
+                        return "bzrk: connection refused", True
+                    return "ok", False
+                return _run
+            bm.run_bzrk = make_run_bzrk(failing_call_substring)
+            try:
+                with self.assertRaises(Exception):
+                    bm._schema_fetcher()
+            finally:
+                bm.run_bzrk = orig_run_bzrk
+
+    def test_schema_fetcher_succeeds_and_returns_data_when_all_four_calls_succeed(self):
+        orig_run_bzrk = bm.run_bzrk
+        bm.run_bzrk = lambda args, timeout=bm.DEFAULT_TIMEOUT: ("some real output", False)
+        try:
+            result = bm._schema_fetcher()
+            self.assertEqual(result["tables"], "some real output")
+            self.assertEqual(result["getschema"], "some real output")
+            self.assertIn("supported_idioms", result)
         finally:
             bm.run_bzrk = orig_run_bzrk
 


### PR DESCRIPTION
## Summary
\`_schema_fetcher()\` discarded the error flag on all four \`run_bzrk\` calls (\`.show tables\`, \`getschema\`, \`fieldstats\`, \`sample\`), so a genuine backend failure never raised. \`schema_registry.get_schema_snapshot()\`'s \`try/except Exception\` fallback (which should downgrade to a stale cache or "unavailable") never triggered — the error text got normalized as if it were real schema output and cached with \`source_status="fresh"\`.

Direct repro from the issue, confirmed fixed:
\`\`\`python
bm.run_bzrk = lambda args, timeout=bm.DEFAULT_TIMEOUT: ("bzrk: authentication failed", True)
bm._schema_snapshot(force=True, allow_refresh=True)
# before: {"source_status": "fresh", ...}
# after:  {"source_status": "unavailable", ...}
\`\`\`

**Design decision** (the issue left this open): any of the four calls failing fails the whole fetch, not just all four. Two reasons: (1) a partial result still means feeding one call's raw error text into \`normalize_snapshot\` as if it were real data, corrupting that section regardless of whether the other three succeeded; (2) \`do_schema()\`, right above \`_schema_fetcher\` in the same file, already uses this exact any-fails semantics (\`e1 or e2\`) — matching it keeps the file internally consistent rather than introducing a second, different failure model.

## Test plan
- [x] Updated the existing test that documented this bug (written during #12/PR #27's Codex review, explicitly left in place with a comment saying it should start failing once #32 landed) to assert the fixed behavior
- [x] Added a direct unit test: fetcher raises when any single one of the four calls fails (parametrized over all four), and returns real data when all succeed
- [x] Re-ran the issue's own repro directly — confirmed \`source_status\` now reads \`unavailable\`, not \`fresh\`
- [x] \`python -m unittest discover -s tests\` — 863 tests, all green
- [x] \`python evals/mcp_protocol_smoke.py --include-http\` — all pass

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)