### PR TITLE
docs: scope v1.26.0 README/release notes to berserk-mcp's own features

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Current version: **1.26.0**. This is a bullet-point overview, most recent
 first — full detail for each notable release lives in
 [`docs/releases/`](docs/releases/).
 
-- **v1.26.0** (2026-08-24) — Untrusted-data fencing, tool tiers, multi-agent
-  ingestion (Codex CLI alongside Claude Code), just-in-time tool discovery
-  (`find_tool`, 92% measured token reduction), a live quota-window check
-  (`claude_quota_status`), OpenRouter telemetry now flowing into Berserk as
-  its own source, and a schema-fetcher bug fix (a failed backend call was
-  silently cached as a "fresh" schema). See [details](docs/releases/v1.26.0.md).
+- **v1.26.0** (2026-08-24) — Untrusted-data fencing, tool tiers, just-in-time
+  tool discovery (`find_tool`, 92% measured token reduction), a live
+  quota-window check (`claude_quota_status`), an `agent` parameter on the base
+  Claude Code query tools for querying other ingested agents' data, and a
+  schema-fetcher bug fix (a failed backend call was silently cached as a
+  "fresh" schema). See [details](docs/releases/v1.26.0.md).
 - **v1.25.1** (2026-08-11) — Performance bugfixes for shipped KQL: selective
   service filtering, shallower unfiltered schema discovery, CI cost guardrails,
   and validator-derived query-budget headroom. See
@@ -457,9 +457,7 @@ Every query tool takes an optional `since` argument (`"15m ago"`, `"1h ago"`,
 ### Claude Code tools (`claude` lane only)
 
 If you ship Claude Code session logs into Berserk (service name `claude-code`), these
-tools mine that data. As of v1.26.0 (issue #42), Codex CLI sessions can ingest
-alongside Claude Code, tagged with their own `service.name` (`codex-cli`). See
-[docs/claude-code.md](docs/claude-code.md) for the pipeline.
+tools mine that data. See [docs/claude-code.md](docs/claude-code.md) for the pipeline.
 
 | Tool | What it answers |
 |---|---|

--- a/docs/releases/v1.26.0.md
+++ b/docs/releases/v1.26.0.md
@@ -1,11 +1,11 @@
-# v1.26.0 — Untrusted-data fencing, tool tiers, multi-agent ingestion, and just-in-time discovery
+# v1.26.0 — Untrusted-data fencing, tool tiers, and just-in-time discovery
 
 Released: 2026-08-24
 
-The largest release since v1.24.0's MCP protocol adaptation. Four real
-capability additions, one new tool, a source-of-truth security fix, and a
-tooling-schema-size lever validated with real model-eval data rather than
-asserted.
+The largest release since v1.24.0's MCP protocol adaptation: three real
+tool-layer capability additions, one new tool, a source-of-truth security
+fix, and a tooling-schema-size lever validated with real model-eval data
+rather than asserted.
 
 ## Features
 
@@ -31,11 +31,10 @@ asserted.
   (`tests/test_tool_discovery.py`) requires every shipped tool to be
   reachable by at least one realistic phrasing before it ships; current
   measured recall is 100% across 210 phrasings.
-- **Multi-agent telemetry ingestion** (issue #42). Codex CLI sessions now
-  ingest alongside Claude Code, tagged by their own `service.name`
-  (`codex-cli`). The five base `claude_*` query tools
-  (`claude_recent`/`claude_sessions`/`claude_tools`/`claude_errors`/`claude_search`)
-  take an optional `agent` parameter, default `claude-code` — fully
+- **`agent` parameter on the base Claude Code query tools** (issue #42).
+  `claude_recent`/`claude_sessions`/`claude_tools`/`claude_errors`/`claude_search`
+  take an optional `agent` parameter, default `claude-code`, letting you
+  query a different ingested agent's data with the same tool — fully
   backward compatible, zero behavior change when omitted.
 - **`claude_quota_status`** (issue #43): a live Claude Code quota-window
   check. Tries a real-time read from Anthropic's account-usage endpoint
@@ -44,19 +43,6 @@ asserted.
   back to a log-derived token estimate over the trailing window when the
   live path is unavailable for any reason. Never requires the ingestion
   daemon running.
-- **OpenRouter telemetry now flows into Berserk as its own source**
-  (issue #55). The existing OpenRouter webhook receiver (v1.25.0-era eval
-  tooling) now forwards every received span into Berserk
-  (`service.name=openrouter`), redacted via `secret_scan` first — every
-  string-valued span attribute, including full prompt/completion text,
-  passes through the same redaction path as every other ingestion source
-  in this project. A resumable backfill tool
-  (`evals/openrouter_backfill_to_berserk.py`) handles already-captured
-  historical data. Real architecture finding from building this: Berserk's
-  ingest exposes both `/v1/traces` and `/v1/logs`, but only `/v1/logs`
-  with the OTLP log-record shape (`timeUnixNano`/`severityNumber`/
-  `severityText`/`body`/`attributes`) actually lands queryable data —
-  `/v1/traces` accepts a span-shaped payload with `200` but never stores it.
 
 ## Fixes
 
@@ -88,9 +74,5 @@ below for the corrected guidance.
 - `evals/mcp_protocol_smoke.py --include-http`: all pass.
 - `find_tool` recall gate: 100% across 210 phrasings covering all 70
   shipped tools.
-- Multi-agent ingestion and OpenRouter forwarding both verified against
-  real deployed infrastructure, not just unit tests — a real signed
-  OpenRouter webhook round-tripped through the receiver into a queryable
-  Berserk record with `service.name=openrouter`, and a real
-  `_schema_fetcher` failure was reproduced end-to-end
+- A real `_schema_fetcher` failure was reproduced end-to-end
   (`source_status` confirmed `"unavailable"`, not `"fresh"`).


### PR DESCRIPTION
## Summary
Follow-up to #60. That PR's release notes conflated two different things: features of berserk-mcp itself (the query/tool layer) and additions to what flows *into* Berserk upstream of it (multi-agent ingestion, the OpenRouter-into-Berserk forwarding pipeline). The latter isn't a berserk-mcp feature — it's a data-source/ingestion concern, out of scope for a README documenting an MCP server's own tools.

- Reframes the multi-agent item around what's actually a berserk-mcp feature: the optional `agent` parameter on the base Claude Code query tools.
- Drops the OpenRouter-forwarding feature bullet entirely — no associated berserk-mcp tool, so nothing to document at this layer.
- The OpenRouter model-eval data **stays**, correctly scoped as setup guidance under "Choosing a model" — real, useful guidance for picking a model to run against berserk-mcp, not a claim about what berserk-mcp ingests.

## Test plan
- [x] `python -m unittest discover -s tests` — 863 tests, all green
- [x] `python evals/mcp_protocol_smoke.py --include-http` — all pass
- [x] Grepped the full README for remaining `OpenRouter`/`ingest` mentions — everything left is either pre-existing legitimate tool content (`sre_ingest_health`, `suggest_ingestion`) or the eval-methodology mention correctly scoped under "Choosing a model"

🤖 Generated with [Claude Code](https://claude.com/claude-code)