### PR TITLE
docs: correct sovereign-deployment model guidance with real eval data

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,13 +233,44 @@ air-gapped environments:
 - **The LLM layer can run locally too.** The parser factory's provider ladder
   speaks the OpenAI-compatible API. Any locally hosted open-weight model —
   via Ollama, llama.cpp, vLLM, or LM Studio — plugs in as the `hermes`
-  endpoint. No frontier API is required. The fixed-query design exists
-  precisely so **small local models route reliably**: the model picks a tool
-  and a time window; it never authors KQL.
+  endpoint. No frontier API is required. The fixed-query design collapses
+  the capability bar the model needs: it picks a tool and a time window; it
+  never authors KQL.
 - **Defense-in-depth on the egress path.** Even when an LLM endpoint is
   configured, it receives only structural telemetry — key names, shapes,
   redacted excerpts — never raw values. The endpoint URL is
   scheme-allowlisted and operator-controlled.
+
+**What we've actually verified about self-hosted model viability**, not just
+asserted (full methodology and data:
+[docs/model-routing-cost-validation-2026-08-23.md](docs/model-routing-cost-validation-2026-08-23.md)).
+This corrects earlier guidance in this section — "small local models route
+reliably" turned out not to hold once measured against this server's real
+70-tool schema, and a sovereignty-focused reader deserves the accurate
+number, not the hopeful one:
+
+- **7-8B local models are not viable.** Qwen2.5:7b and Llama3.1:8b, tested
+  locally via Ollama against the real schema, scored 5-7% tool-selection
+  accuracy — far below a dumb keyword-matching baseline (66%). Public
+  tool-calling benchmarks (BFCL) rank these families well, but those
+  benchmarks measure a much smaller tool count; they are not a reliable
+  predictor at this schema size (see the now-superseded shortlist in
+  [`evals/model-eval-plan.md`](evals/model-eval-plan.md)).
+- **The measured reliability floor is the ~24B parameter class**, and one
+  real candidate at that tier is confirmed genuinely self-hostable under an
+  open license: `mistral-small-3.2-24b-instruct` (Apache 2.0, confirmed on
+  Hugging Face, ~55GB GPU RAM at bf16) reached 78% tool-selection accuracy
+  in the same eval. Its numbers come from the same OpenRouter-hosted eval as
+  every other candidate, not from an actual local deployment — self-hosted
+  latency and behavior on that specific hardware profile is not yet
+  independently verified.
+- One size class down (`mistral-nemo`, ~12B) scored *below* the
+  keyword-matching baseline — smaller is not a safe default assumption
+  anywhere in this range.
+- **Bottom line for a sovereign deployment today:** budget for a ≥24B-class
+  open-weight model and a GPU, not a small one. A fully local setup with a
+  genuinely small (7-8B) first tier is not yet a validated configuration
+  against this server's tool count.
 
 #### Bridging Berserk's two use cases: AI Ops without leaving the sovereign boundary
 
@@ -273,12 +304,21 @@ family (`claude_cost_report`, `claude_token_burn`, `claude_workflow_insights`,
 and others) delivers the same token-usage/BI story from that page. These
 tools are already implemented and already answering real queries.
 
-The target operating model is **two-tier local**. A small open-weight model
-handles the everyday calls; the goal is ≥ 80% of interactions. The model
-escalates to a larger, locally hosted open-weight model only for `@deep`
-work: parser generation, deep-dive synthesis, incident narratives. The
-measurement plan for picking both tiers is in
-[`evals/model-eval-plan.md`](evals/model-eval-plan.md) (Part 3).
+The target operating model is **two-tier local**. A locally hosted
+open-weight model at the measured reliability floor (~24B class — see
+above) handles the everyday calls; the goal is ≥ 80% of interactions. The
+model escalates to a larger, locally hosted open-weight model only for
+`@deep` work: parser generation, deep-dive synthesis, incident narratives.
+"Small" here means the smaller of the two local tiers, not a 7-8B model —
+those were tested and are not reliable enough to anchor either tier. The
+escalation mechanism itself (a policy deciding when to route up)
+is implemented and tested against a cloud-hosted small/deep pair in
+`evals/escalation_policy.py`; picking and verifying the actual local model
+for each tier against real hardware is still open. The original
+measurement plan is in
+[`evals/model-eval-plan.md`](evals/model-eval-plan.md) (Part 3) — read its
+Part 1 benchmark shortlist skeptically; it predates the real eval above and
+its picks did not hold up at this server's actual tool count.
 
 ---
 

--- a/evals/model-eval-plan.md
+++ b/evals/model-eval-plan.md
@@ -1,5 +1,15 @@
 # Model evaluation plan — which LLM to pair with berserk-mcp
 
+**Part 2's harness has now been run for real** — see
+[docs/model-routing-cost-validation-2026-08-23.md](../docs/model-routing-cost-validation-2026-08-23.md)
+for the actual data. Read Part 1's benchmark-based shortlist below with that
+in mind: it was written when this server had 19 tools; the real schema has
+since grown to 69-70, and the real eval found the exact families Part 1
+favored (Qwen2.5, Llama 3.1, both 7-8B) score 5-7% tool-selection accuracy
+against the current schema — public tool-calling benchmarks measured at a
+much smaller tool count were not a reliable predictor here. Kept below for
+the historical reasoning, not as current guidance.
+
 Goal: find the **cheapest model (ideally local) that reliably drives this MCP** for the
 real question distribution, and quantify how much the server design (tool descriptions,
 `instructions`, annotations) contributes versus the model.


### PR DESCRIPTION
## Summary
The "Sovereign and defense deployments" section claimed **"small local models route reliably"** and built a two-tier local architecture around "a small open-weight model handles the everyday calls" — both now directly contradicted by real testing already cited elsewhere in this README: 7-8B local models (Qwen2.5:7b, Llama3.1:8b) scored 5-7% tool-selection accuracy against the real 70-tool schema, below a dumb keyword-matching baseline. This is exactly the wrong place to leave an overclaimed reliability statement uncorrected — it's the section a defense/sovereignty-constrained reader would actually rely on to make a real deployment decision.

- Corrects the reliability claim with the real floor (~24B class, not "small").
- Adds the concrete, missing finding: one open-weight model at that floor is confirmed genuinely self-hostable under an open license — `mistral-small-3.2-24b-instruct` (Apache 2.0, confirmed on Hugging Face, ~55GB GPU RAM at bf16, 78% tool-selection accuracy) — explicitly flagged as not yet independently verified on real local hardware (the eval itself ran via OpenRouter).
- Updates the "two-tier local" target operating model paragraph to reflect that a genuinely small (7-8B) first tier is not a validated configuration.
- Flags `evals/model-eval-plan.md`'s Part 1 benchmark-based shortlist (written when this server had 19 tools) as superseded now that the schema has grown to 69-70 tools — kept for historical reasoning, not current guidance.

Scoped to model-reliability data only, per earlier direction to keep the README on berserk-mcp's own tool-layer concerns — this is squarely "which model to run against these tools," not an ingestion/data-source claim.

## Test plan
- [x] `python -m unittest discover -s tests` — 863 tests, all green
- [x] `python evals/mcp_protocol_smoke.py --include-http` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)