### PR TITLE
feat: investigate_error_rate — fixed decision-tree investigation tool (issue #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Every query tool takes an optional `since` argument (`"15m ago"`, `"1h ago"`,
 | Tool | What it answers |
 |---|---|
 | `sre_error_rate` | Error log events by service grouped per minute — "is the error rate climbing?" |
+| `investigate_error_rate` | Fixed decision-tree root-cause walk for an elevated error rate — errors_by_service → correlated log-spike → failing traces, one hop per call. |
 | `sre_host_headroom` | CPU load and memory by host — "which VM is saturated?" |
 | `sre_ingest_health` | Berserk ingest lag and dropped data — "is observability lagging?" |
 | `sre_service_health` | Full health summary for one named service: event volume, error count, log/metric split, last seen. |

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -2803,8 +2803,10 @@ def _handle_call_uncached(name, arguments):
 
     if name == "investigate_error_rate":
         node = str(arguments.get("node") or "start").strip()
-        service = arguments.get("service")
-        service = str(service).strip() if service else None
+        service = str(arguments.get("service") or "").strip()
+        if service and not _valid_interpolated_name(service):
+            return "invalid service name (allowed: letters, digits, '.', '_', '-')", True
+        service = service or None
         since = arguments.get("since") or "1h ago"
         text, is_err, _next_node = investigation.run_error_rate_node(node, since, service)
         return _fence_untrusted(text), is_err

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -72,6 +72,7 @@ from pathlib import Path
 import _http
 import _store
 import agent_analytics
+import investigation
 import ai_finops
 import ingestion_advisor
 import kql_validation
@@ -1910,6 +1911,13 @@ agent_analytics.configure(
     )[0],
     fence=lambda text: _fence_untrusted(text, inline=True),
 )
+investigation.configure(
+    bzrk_search=bzrk_search_json,
+    since_hours=_since_hours,
+    q_errors=Q_ERRORS,
+    q_soc_log_spike=Q_SOC_LOG_SPIKE,
+    q_trace_find_errors=Q_TRACE_FIND_ERRORS,
+)
 ai_finops.configure(
     search=bzrk_search_json,
     table=TABLE,
@@ -2245,6 +2253,7 @@ TOOLS = [
     {"name": "trace_analyze", "description": "Full breakdown of one trace by trace_id — every span in time order plus correlated log lines from the same trace_id. Use after trace_find_slow/trace_find_errors surface a trace_id worth investigating.", "inputSchema": {"type": "object", "properties": {"trace_id": {"type": "string", "maxLength": MAX_TRACE_ID_CHARS, "description": "trace_id from trace_find_slow/trace_find_errors/search"}}, "required": ["trace_id"]}},
     # --- SRE role tools (reliability, headroom, saturation, error rates, rollback signals) ---
     {"name": "sre_error_rate", "roles": ["sre"], "description": "SRE view of ERROR log events grouped by service and minute. Use for 'is the error rate climbing', 'which service is burning error budget', or 'what should we rollback first'.", "inputSchema": {"type": "object", "properties": _since()}},
+    {"name": "investigate_error_rate", "roles": ["sre"], "description": "Fixed decision-tree investigation for an elevated error rate: checks errors_by_service, and if elevated, walks correlated log-volume spike and failing-trace checks — one hop per call, reproducible, no agent-authored composition. Start with no arguments (or node='start'); each response tells you the next call to make.", "inputSchema": {"type": "object", "properties": dict({"node": {"type": "string", "description": "which hop to run; omit or 'start' to begin a new investigation"}, "service": {"type": "string", "maxLength": MAX_INTERPOLATED_NAME_CHARS, "description": "required for node='check_log_spike'/'check_traces' — the service name the previous step's response gave you"}}, **_since())}},
     {"name": "forecast_capacity", "roles": ["sre"], "description": "Forecast when an allowlisted host gauge may reach its ceiling using a native series fit. Use for 'when will memory fill?' or 'at this trend when does capacity run out?'. Refuses unreliable trends instead of inventing a date.", "inputSchema": {"type": "object", "properties": dict({"metric": {"type": "string", "enum": sorted(_FORECAST_METRICS)}, "host": {"type": "string", "maxLength": MAX_INTERPOLATED_NAME_CHARS, "description": "optional host.name filter"}}, **_since()), "required": ["metric"]}},
     {"name": "sre_host_headroom", "roles": ["sre"], "description": "SRE view of host CPU load and memory used side-by-side. Use for 'which host is hottest', 'where is headroom lowest', or 'which VM is nearest saturation'.", "inputSchema": {"type": "object", "properties": _since()}},
     {"name": "sre_ingest_health", "roles": ["sre"], "description": "SRE view of Berserk ingest lag and dropped-data signals per host. Use for 'is ingest healthy', 'are we dropping telemetry', or 'is observability lagging'.", "inputSchema": {"type": "object", "properties": _since()}},
@@ -2367,6 +2376,7 @@ TITLES = {
     "list_metrics": "List Metrics",
     "bzrk_query_perf": "Berserk Query Performance",
     "sre_error_rate": "SRE: Error Rate",
+    "investigate_error_rate": "Investigate: Error Rate",
     "sre_host_headroom": "SRE: Host Headroom",
     "sre_ingest_health": "SRE: Ingest Health",
     "sre_service_health": "SRE: Service Health",
@@ -2790,6 +2800,14 @@ def _handle_call_uncached(name, arguments):
         if not out or out.strip() == "(no rows)":
             return f"No anomalies detected (window {since}).", False
         return f"Anomaly decomposition for window {since}; non-zero anomaly markers indicate spikes:\n{_fence_untrusted(out)}", False
+
+    if name == "investigate_error_rate":
+        node = str(arguments.get("node") or "start").strip()
+        service = arguments.get("service")
+        service = str(service).strip() if service else None
+        since = arguments.get("since") or "1h ago"
+        text, is_err, _next_node = investigation.run_error_rate_node(node, since, service)
+        return _fence_untrusted(text), is_err
 
     if name == "forecast_capacity":
         metric = str(arguments.get("metric") or "").strip()

--- a/docs/investigation-decision-tree-implementation-spec.md
+++ b/docs/investigation-decision-tree-implementation-spec.md
@@ -1,6 +1,6 @@
 # Investigation decision tree: implementation spec
 
-Status: DRAFT — brainstormed and approved 2026-08-27, not yet implemented.
+Status: IMPLEMENTED — brainstormed and approved 2026-08-27, shipped 2026-08-28.
 Addresses issue #24 ("Investigation decision tree, composition ceiling, no
 code execution"), which itself derives from `docs/berserk-dev-brief-2026-08-20.md`
 §3's "composition ceiling" weakness and §5 priority item 8.

--- a/evals/router_cases.jsonl
+++ b/evals/router_cases.jsonl
@@ -39,3 +39,4 @@
 {"id": "jworkflow_sequences", "prompt": "What tool sequences does Claude Code use most often?", "expect_tool": "claude_workflow_insights", "tier": "small"}
 {"id": "jworkflow_hotspots", "prompt": "Where are the error hotspots across Claude Code sessions?", "expect_tool": "claude_workflow_insights", "tier": "small"}
 {"id": "jworkflow_burn", "prompt": "Which sessions are burning the most tokens relative to their targets?", "expect_tool": "claude_workflow_insights", "tier": "small"}
+{"id": "investigate_error_spike", "prompt": "why is checkout-service's error rate elevated? I want the root cause, not just the count.", "expect_tool": "investigate_error_rate"}

--- a/evals/run_eval.py
+++ b/evals/run_eval.py
@@ -194,6 +194,8 @@ def call_mock(user, tools):
             return "claude_recent"
         if "log" in p:
             return "logs_for_service"
+        if "root cause" in p or ("investigat" in p and "error" in p):
+            return "investigate_error_rate"
         if "error" in p:
             return "errors_by_service"
         if "cpu" in p:

--- a/investigation.py
+++ b/investigation.py
@@ -29,6 +29,7 @@ ERROR_RATE_INVESTIGATE_PER_MIN = 10
 # exists yet; revisit once this tree has run against live incidents.
 _RECENT_BUCKET_COUNT = 5
 _SPIKE_MULTIPLIER = 3
+_MIN_SPIKE_BUCKETS = _RECENT_BUCKET_COUNT * 2  # need real baseline, not just recent
 
 
 def configure(bzrk_search, since_hours, q_errors, q_soc_log_spike, q_trace_find_errors):
@@ -129,12 +130,79 @@ def _node_start(since):
     )
 
 
+def _node_check_log_spike(since, service):
+    if not service:
+        return (
+            "check_log_spike requires service (pass the value the start "
+            "node's response gave you).",
+            True, None,
+        )
+    rows, err = _run_json(_q_soc_log_spike, since)
+    if err is not None:
+        return (
+            f"Checked: soc_log_spike (since={since}) — FAILED\n"
+            f"Error: {err}\n"
+            f"Investigation halted at check_log_spike. The error-rate "
+            f"elevation from the previous step is still valid; this "
+            f"step's result is unknown, not \"no spike.\"",
+            True, None,
+        )
+    row = next((r for r in rows if str(r.get("service")) == service), None)
+    if row is None:
+        return (
+            f"Checked: soc_log_spike (since={since})\n"
+            f"No log-volume data for service={service!r} in this window "
+            f"— FAILED\n"
+            f"Investigation halted at check_log_spike.",
+            True, None,
+        )
+    hits = row.get("hits")
+    if not isinstance(hits, list) or len(hits) < _MIN_SPIKE_BUCKETS:
+        return (
+            f"Checked: soc_log_spike (since={since})\n"
+            f"Result: insufficient buckets for service={service!r} to "
+            f"assess a spike (need >= {_MIN_SPIKE_BUCKETS}) — FAILED\n"
+            f"Investigation halted at check_log_spike.",
+            True, None,
+        )
+    recent = hits[-_RECENT_BUCKET_COUNT:]
+    baseline = hits[:-_RECENT_BUCKET_COUNT]
+    recent_mean = sum(recent) / len(recent)
+    baseline_mean = sum(baseline) / len(baseline)
+    is_spike = (
+        recent_mean > 0 if baseline_mean == 0
+        else recent_mean > baseline_mean * _SPIKE_MULTIPLIER
+    )
+    if not is_spike:
+        return (
+            f"Checked: soc_log_spike (since={since})\n"
+            f"Result: service={service!r} recent volume {recent_mean:.1f}/min "
+            f"vs baseline {baseline_mean:.1f}/min — not a spike "
+            f"(threshold {_SPIKE_MULTIPLIER}x)\n"
+            f"Investigation complete.\n"
+            f"Verdict: error rate elevated for {service!r} but no "
+            f"correlated log-volume spike; recommend manual review.",
+            False, None,
+        )
+    return (
+        f"Checked: soc_log_spike (since={since})\n"
+        f"Result: service={service!r} recent volume {recent_mean:.1f}/min "
+        f"vs baseline {baseline_mean:.1f}/min — spike confirmed\n"
+        f"Branch: correlated spike\n"
+        f"Next: call investigate_error_rate(node=\"check_traces\", "
+        f"since={since!r}, service=\"{service}\") to continue.",
+        False, "check_traces",
+    )
+
+
 def run_error_rate_node(node, since, service):
     """Execute exactly one hop of the elevated-error-rate tree. Returns
     (text, is_error, next_node) -- next_node is None at every terminal
     state (concluded or halted)."""
     if node == "start":
         return _node_start(since)
+    if node == "check_log_spike":
+        return _node_check_log_spike(since, service)
     return (
         f"Unknown node {node!r}. Call investigate_error_rate with no "
         f"node argument (or node=\"start\") to begin a new investigation.",

--- a/investigation.py
+++ b/investigation.py
@@ -30,6 +30,7 @@ ERROR_RATE_INVESTIGATE_PER_MIN = 10
 _RECENT_BUCKET_COUNT = 5
 _SPIKE_MULTIPLIER = 3
 _MIN_SPIKE_BUCKETS = _RECENT_BUCKET_COUNT * 2  # need real baseline, not just recent
+_MAX_EXAMPLE_TRACES = 3
 
 
 def configure(bzrk_search, since_hours, q_errors, q_soc_log_spike, q_trace_find_errors):
@@ -195,6 +196,50 @@ def _node_check_log_spike(since, service):
     )
 
 
+def _node_check_traces(since, service):
+    if not service:
+        return (
+            "check_traces requires service (pass the value the previous "
+            "step's response gave you).",
+            True, None,
+        )
+    rows, err = _run_json(_q_trace_find_errors, since)
+    if err is not None:
+        return (
+            f"Checked: trace_find_errors (since={since}) — FAILED\n"
+            f"Error: {err}\n"
+            f"Investigation halted at check_traces.",
+            True, None,
+        )
+    matching = [r for r in rows if str(r.get("service")) == service]
+    if not matching:
+        return (
+            f"Checked: trace_find_errors (since={since})\n"
+            f"Result: no failing traces found for service={service!r}\n"
+            f"Investigation complete.\n"
+            f"Verdict: error rate elevated, correlated log-volume spike "
+            f"confirmed for {service!r}, but no failing traces found — "
+            f"investigate ingestion lag or a non-trace-instrumented "
+            f"failure path.",
+            False, None,
+        )
+    examples = "; ".join(
+        f"{r.get('span_name')} ({r.get('trace_id')})"
+        for r in matching[:_MAX_EXAMPLE_TRACES]
+    )
+    return (
+        f"Checked: trace_find_errors (since={since})\n"
+        f"Result: {len(matching)} failing traces found for "
+        f"service={service!r}: {examples}\n"
+        f"Investigation complete.\n"
+        f"Verdict: error rate elevated, correlated log-volume spike "
+        f"confirmed, {len(matching)} failing traces found for "
+        f"{service!r} — root cause is likely in {service!r}'s own "
+        f"request path, not a downstream dependency.",
+        False, None,
+    )
+
+
 def run_error_rate_node(node, since, service):
     """Execute exactly one hop of the elevated-error-rate tree. Returns
     (text, is_error, next_node) -- next_node is None at every terminal
@@ -203,6 +248,8 @@ def run_error_rate_node(node, since, service):
         return _node_start(since)
     if node == "check_log_spike":
         return _node_check_log_spike(since, service)
+    if node == "check_traces":
+        return _node_check_traces(since, service)
     return (
         f"Unknown node {node!r}. Call investigate_error_rate with no "
         f"node argument (or node=\"start\") to begin a new investigation.",

--- a/investigation.py
+++ b/investigation.py
@@ -1,0 +1,142 @@
+"""SRE fault-isolation decision trees (issue #24).
+
+Fixed, hardcoded per-intent trees -- no agent-authored composition, same
+reproducibility posture as every other tool in this project. This module
+is stdlib-only and configured by berserk_mcp.py at import time. It does
+not import berserk_mcp directly, which keeps tests simple and avoids
+cycles (same convention as agent_analytics.py and parser_factory.py).
+
+Design: docs/investigation-decision-tree-implementation-spec.md
+"""
+import json
+
+import agent_analytics
+
+_bzrk_search = None
+_since_hours = None
+_q_errors = None
+_q_soc_log_spike = None
+_q_trace_find_errors = None
+
+# From primers/sre.md's "Escalation thresholds" table. Single source of
+# truth for this module; the primer's prose copy is not auto-synced
+# (spec's documented follow-up, not fixed here).
+ERROR_RATE_INVESTIGATE_PER_MIN = 10
+
+# How many trailing buckets of soc_log_spike's per-minute series count as
+# "recent" vs. baseline, and how many multiples of the baseline mean counts
+# as a spike. Conservative starting values -- no real-traffic tuning data
+# exists yet; revisit once this tree has run against live incidents.
+_RECENT_BUCKET_COUNT = 5
+_SPIKE_MULTIPLIER = 3
+
+
+def configure(bzrk_search, since_hours, q_errors, q_soc_log_spike, q_trace_find_errors):
+    """bzrk_search: callable(kql, since) -> (json_text, is_error), the same
+    bzrk_search_json berserk_mcp.py wires into agent_analytics. since_hours:
+    callable(since_str) -> float hours, berserk_mcp.py's own _since_hours
+    (passed in rather than imported, to avoid the cycle). q_*: the exact
+    KQL constants berserk_mcp.py already defines for errors_by_service,
+    soc_log_spike, and trace_find_errors -- reused verbatim so this tree's
+    queries never drift from the fixed tools' own."""
+    global _bzrk_search, _since_hours, _q_errors, _q_soc_log_spike, _q_trace_find_errors
+    _bzrk_search = bzrk_search
+    _since_hours = since_hours
+    _q_errors = q_errors
+    _q_soc_log_spike = q_soc_log_spike
+    _q_trace_find_errors = q_trace_find_errors
+
+
+def _run_json(kql, since):
+    """Run one KQL query in JSON mode and return (rows, error_text).
+
+    rows is a list of dicts on success (empty list for a genuinely empty
+    result, not an error), None on any failure. Reuses
+    agent_analytics._json_records for the same Tables[0].schema/rows
+    parsing every other analytics module in this project already relies
+    on -- never hand-rolls a second parser for the same wire shape.
+    Branch logic downstream always operates on these structured values,
+    never on a fixed tool's own formatted display text."""
+    out, is_err = _bzrk_search(kql, since)
+    if is_err:
+        return None, out
+    # bzrk's --json mode still returns the plain text sentinel "(no rows)"
+    # for a genuinely empty result, not an empty JSON array -- the same
+    # convention agent_analytics._parse_rows already handles explicitly.
+    # Without this check, an empty result would be misreported as
+    # "unexpected non-JSON response" and halt the investigation instead
+    # of correctly concluding "no errors, nothing to investigate."
+    if str(out or "").strip() == "(no rows)":
+        return [], None
+    try:
+        parsed = json.loads(out)
+    except (json.JSONDecodeError, TypeError):
+        return None, f"unexpected non-JSON response: {out[:200]}"
+    records = agent_analytics._json_records(parsed)
+    if records is None:
+        return None, f"unrecognized response shape: {out[:200]}"
+    return records, None
+
+
+def _as_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _node_start(since):
+    rows, err = _run_json(_q_errors, since)
+    if err is not None:
+        return (
+            f"Checked: errors_by_service (since={since}) — FAILED\n"
+            f"Error: {err}\n"
+            f"Investigation halted at start.",
+            True, None,
+        )
+    if not rows:
+        return (
+            f"Checked: errors_by_service (since={since})\n"
+            f"Result: no errors\n"
+            f"Investigation complete.\n"
+            f"Verdict: no errors in window, nothing to investigate.",
+            False, None,
+        )
+    top = max(rows, key=lambda r: _as_int(r.get("errors")))
+    service = str(top.get("service") or "(unknown)")
+    count = _as_int(top.get("errors"))
+    hours = _since_hours(since)
+    rate = (count / (60.0 * hours)) if hours > 0 else 0.0
+    if rate <= ERROR_RATE_INVESTIGATE_PER_MIN:
+        return (
+            f"Checked: errors_by_service (since={since})\n"
+            f"Result: worst service is {service!r} at {count} errors "
+            f"(~{rate:.1f}/min)\n"
+            f"Threshold: >{ERROR_RATE_INVESTIGATE_PER_MIN}/min to investigate\n"
+            f"Investigation complete.\n"
+            f"Verdict: error rate normal, no further checks.",
+            False, None,
+        )
+    return (
+        f"Checked: errors_by_service (since={since})\n"
+        f"Result: {count} errors for service {service!r} (~{rate:.1f}/min)\n"
+        f"Threshold: >{ERROR_RATE_INVESTIGATE_PER_MIN}/min investigate\n"
+        f"Branch: investigate (elevated)\n"
+        f"Next: call investigate_error_rate(node=\"check_log_spike\", "
+        f"since={since!r}, service=\"{service}\") to continue, or stop "
+        f"here if this is enough.",
+        False, "check_log_spike",
+    )
+
+
+def run_error_rate_node(node, since, service):
+    """Execute exactly one hop of the elevated-error-rate tree. Returns
+    (text, is_error, next_node) -- next_node is None at every terminal
+    state (concluded or halted)."""
+    if node == "start":
+        return _node_start(since)
+    return (
+        f"Unknown node {node!r}. Call investigate_error_rate with no "
+        f"node argument (or node=\"start\") to begin a new investigation.",
+        True, None,
+    )

--- a/primers/sre.md
+++ b/primers/sre.md
@@ -8,6 +8,7 @@ signals, and give operators the data they need to decide whether to page, roll b
 | Question | Tool |
 |---|---|
 | Is error rate climbing? | `sre_error_rate` |
+| Why is error rate elevated — full root-cause walk, not just the number? | `investigate_error_rate` |
 | Which host is under pressure? | `sre_host_headroom` |
 | Is Berserk itself healthy? | `sre_ingest_health` |
 | What's the worst recurring error message? | `sre_top_error_messages` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ berserk-mcp = "berserk_mcp:main"
 berserk-claude = "ai_finops:launcher_main"
 
 [tool.setuptools]
-py-modules = ["berserk_mcp", "parser_factory", "agent_analytics", "ai_finops", "secret_scan", "ingestion_advisor", "kql_validation", "schema_registry", "_store", "_http", "tool_discovery", "quota_status"]
+py-modules = ["berserk_mcp", "parser_factory", "agent_analytics", "ai_finops", "secret_scan", "ingestion_advisor", "kql_validation", "schema_registry", "_store", "_http", "tool_discovery", "quota_status", "investigation"]
 
 [tool.setuptools.data-files]
 "share/berserk-mcp" = ["ingestion_catalog.json", "pricing_catalog.json"]

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -6268,6 +6268,21 @@ class InvestigateErrorRateTest(unittest.TestCase):
         self.assertTrue(err)
         self.assertIn("unknown node", text.lower())
 
+    def test_rejects_invalid_service_name(self):
+        text, err = bm.handle_call("investigate_error_rate", {"service": "bad name!"})
+        self.assertTrue(err)
+        self.assertIn("invalid service name", text)
+        self.assertIn("allowed: letters, digits, '.', '_', '-'", text)
+
+    def test_accepts_valid_service_name(self):
+        doc = {"Tables": [{
+            "schema": {"columns": [{"name": "service"}, {"name": "errors"}]},
+            "rows": [["my-service", 5]],
+        }]}
+        self._mock_bzrk(json.dumps(doc))
+        text, err = bm.handle_call("investigate_error_rate", {"service": "my-service"})
+        self.assertFalse(err, text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -6241,5 +6241,33 @@ class ToolSchemaValidityTest(unittest.TestCase):
         self.assertEqual(roles_schema["items"], {"type": "string"})
 
 
+class InvestigateErrorRateTest(unittest.TestCase):
+    def setUp(self):
+        self._orig = bm.run_bzrk
+
+    def tearDown(self):
+        bm.run_bzrk = self._orig
+
+    def _mock_bzrk(self, out, err=False):
+        bm.run_bzrk = lambda args, timeout=bm.DEFAULT_TIMEOUT: (out, err)
+
+    def test_start_node_dispatches_and_returns_text(self):
+        doc = {"Tables": [{
+            "schema": {"columns": [{"name": "service"}, {"name": "errors"}]},
+            "rows": [["checkout", 5]],
+        }]}
+        self._mock_bzrk(json.dumps(doc))
+        text, err = bm.handle_call("investigate_error_rate", {})
+        self.assertFalse(err, text)
+        self.assertIn("normal", text.lower())
+
+    def test_unknown_node_is_reported_as_error(self):
+        self._mock_bzrk("(no rows)")
+        text, err = bm.handle_call(
+            "investigate_error_rate", {"node": "not_a_real_node"})
+        self.assertTrue(err)
+        self.assertIn("unknown node", text.lower())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_investigation.py
+++ b/tests/test_investigation.py
@@ -235,5 +235,88 @@ class CheckTracesNodeTest(unittest.TestCase):
         self.assertIsNone(next_node)
 
 
+class FullWalkTest(unittest.TestCase):
+    def setUp(self):
+        inv.configure(
+            bzrk_search=self._search, since_hours=lambda s: 1.0,
+            q_errors="Q_ERRORS", q_soc_log_spike="Q_SPIKE", q_trace_find_errors="Q_TRACE",
+        )
+        self.responses = {}
+
+    def _search(self, kql, since):
+        return self.responses[kql]
+
+    def test_full_walk_elevated_spike_traces_found(self):
+        self.responses["Q_ERRORS"] = (
+            bzrk_json_table(["service", "errors"], [["checkout", 700]]), False)
+        self.responses["Q_SPIKE"] = (
+            bzrk_json_table(["service", "hits"], [["checkout", [2] * 55 + [20] * 5]]), False)
+        self.responses["Q_TRACE"] = (
+            bzrk_json_table(
+                ["trace_id", "span_name", "timestamp", "service"],
+                [["t1", "POST /checkout", "2026-08-28T00:00:00Z", "checkout"]],
+            ), False)
+
+        text1, err1, next1 = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertFalse(err1)
+        self.assertEqual(next1, "check_log_spike")
+
+        text2, err2, next2 = inv.run_error_rate_node("check_log_spike", "1h ago", "checkout")
+        self.assertFalse(err2)
+        self.assertEqual(next2, "check_traces")
+
+        text3, err3, next3 = inv.run_error_rate_node("check_traces", "1h ago", "checkout")
+        self.assertFalse(err3)
+        self.assertIsNone(next3)
+        self.assertIn("root cause is likely", text3)
+
+    def test_full_walk_elevated_but_no_spike_early_exit(self):
+        self.responses["Q_ERRORS"] = (
+            bzrk_json_table(["service", "errors"], [["checkout", 700]]), False)
+        self.responses["Q_SPIKE"] = (
+            bzrk_json_table(["service", "hits"], [["checkout", [5] * 60]]), False)
+
+        _, err1, next1 = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertFalse(err1)
+        self.assertEqual(next1, "check_log_spike")
+
+        text2, err2, next2 = inv.run_error_rate_node("check_log_spike", "1h ago", "checkout")
+        self.assertFalse(err2)
+        self.assertIsNone(next2)
+        self.assertIn("manual review", text2.lower())
+
+
+class DisplayFormatIndependenceTest(unittest.TestCase):
+    """Proves the architecture decision (branch logic never depends on a
+    fixed tool's display-formatted text) actually holds, not just that
+    it's stated as intent (spec's own required regression test)."""
+
+    def test_branch_logic_unaffected_by_reformatted_but_same_structured_value(self):
+        # Two structurally-identical responses that would render as very
+        # different display text if a fixed tool changed its formatting
+        # (different key order, extra whitespace) but carry the same
+        # decision-relevant value. Branch outcome must be identical.
+        variant_a = json.dumps({"Tables": [{
+            "schema": {"columns": [{"name": "service"}, {"name": "errors"}]},
+            "rows": [["checkout", 700]],
+        }]})
+        variant_b = json.dumps({"Tables": [{
+            "schema": {"columns": [{"name": "errors"}, {"name": "service"}]},
+            "rows": [[700, "checkout"]],
+        }]}, indent=4)  # different formatting, different column order
+
+        for variant in (variant_a, variant_b):
+            with self.subTest(variant=variant[:30]):
+                inv.configure(
+                    bzrk_search=lambda kql, since, v=variant: (v, False),
+                    since_hours=lambda s: 1.0,
+                    q_errors="Q_ERRORS", q_soc_log_spike="Q_SPIKE",
+                    q_trace_find_errors="Q_TRACE",
+                )
+                _, is_error, next_node = inv.run_error_rate_node("start", "1h ago", None)
+                self.assertFalse(is_error)
+                self.assertEqual(next_node, "check_log_spike")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_investigation.py
+++ b/tests/test_investigation.py
@@ -1,0 +1,122 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import investigation as inv  # noqa: E402
+
+
+def bzrk_json_table(columns, rows):
+    """Build the exact bzrk --json shape agent_analytics._json_records
+    parses: {"Tables": [{"schema": {"columns": [...]}, "rows": [[...]]}]}."""
+    return json.dumps({"Tables": [{
+        "schema": {"columns": [{"name": c} for c in columns]},
+        "rows": rows,
+    }]})
+
+
+class RunJsonTest(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+
+    def test_returns_parsed_rows_on_success(self):
+        def fake_search(kql, since):
+            self.calls.append((kql, since))
+            return bzrk_json_table(["service", "errors"], [["checkout", 23]]), False
+        inv.configure(
+            bzrk_search=fake_search, since_hours=lambda s: 1.0,
+            q_errors="Q1", q_soc_log_spike="Q2", q_trace_find_errors="Q3",
+        )
+        rows, err = inv._run_json("Q1", "1h ago")
+        self.assertIsNone(err)
+        self.assertEqual(rows, [{"service": "checkout", "errors": 23}])
+        self.assertEqual(self.calls, [("Q1", "1h ago")])
+
+    def test_backend_error_returns_error_text_not_rows(self):
+        inv.configure(
+            bzrk_search=lambda kql, since: ("bzrk timed out", True),
+            since_hours=lambda s: 1.0,
+            q_errors="Q1", q_soc_log_spike="Q2", q_trace_find_errors="Q3",
+        )
+        rows, err = inv._run_json("Q1", "1h ago")
+        self.assertIsNone(rows)
+        self.assertEqual(err, "bzrk timed out")
+
+    def test_non_json_response_is_reported_not_silently_empty(self):
+        inv.configure(
+            bzrk_search=lambda kql, since: ("not json at all", False),
+            since_hours=lambda s: 1.0,
+            q_errors="Q1", q_soc_log_spike="Q2", q_trace_find_errors="Q3",
+        )
+        rows, err = inv._run_json("Q1", "1h ago")
+        self.assertIsNone(rows)
+        self.assertIn("unexpected non-JSON response", err)
+
+    def test_no_rows_sentinel_returns_empty_list_not_an_error(self):
+        # bzrk's --json mode still returns the plain-text "(no rows)"
+        # sentinel for a genuinely empty result, not an empty JSON array.
+        # This must be treated as success-with-zero-rows, not a parse
+        # failure -- caught during implementation verification, not
+        # written speculatively (a real bug in an earlier draft of this
+        # code halted every empty-result investigation with "unexpected
+        # non-JSON response" instead of concluding cleanly).
+        inv.configure(
+            bzrk_search=lambda kql, since: ("(no rows)", False),
+            since_hours=lambda s: 1.0,
+            q_errors="Q1", q_soc_log_spike="Q2", q_trace_find_errors="Q3",
+        )
+        rows, err = inv._run_json("Q1", "1h ago")
+        self.assertIsNone(err)
+        self.assertEqual(rows, [])
+
+
+class StartNodeTest(unittest.TestCase):
+    def setUp(self):
+        inv.configure(
+            bzrk_search=self._search, since_hours=lambda s: 1.0,
+            q_errors="Q_ERRORS", q_soc_log_spike="Q_SPIKE", q_trace_find_errors="Q_TRACE",
+        )
+        self.responses = {}
+
+    def _search(self, kql, since):
+        return self.responses[kql]
+
+    def test_normal_rate_concludes(self):
+        # 5 errors over a 1h window = 5/60 per-minute, below the 10/min gate.
+        self.responses["Q_ERRORS"] = (
+            bzrk_json_table(["service", "errors"], [["checkout", 5]]), False)
+        text, is_error, next_node = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertFalse(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("normal", text.lower())
+
+    def test_elevated_rate_advances_to_check_log_spike(self):
+        # 700 errors over 1h = ~11.7/min, above the 10/min gate.
+        self.responses["Q_ERRORS"] = (
+            bzrk_json_table(["service", "errors"], [["checkout", 700], ["auth", 3]]), False)
+        text, is_error, next_node = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertFalse(is_error)
+        self.assertEqual(next_node, "check_log_spike")
+        self.assertIn("checkout", text)
+        self.assertIn("check_log_spike", text)
+        self.assertIn("service=\"checkout\"", text)
+
+    def test_no_rows_concludes_nothing_to_investigate(self):
+        self.responses["Q_ERRORS"] = ("(no rows)", False)
+        text, is_error, next_node = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertFalse(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("no errors", text.lower())
+
+    def test_backend_failure_halts_and_reports(self):
+        self.responses["Q_ERRORS"] = ("bzrk timed out after 120s", True)
+        text, is_error, next_node = inv.run_error_rate_node("start", "1h ago", None)
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("FAILED", text)
+        self.assertIn("bzrk timed out after 120s", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_investigation.py
+++ b/tests/test_investigation.py
@@ -118,5 +118,71 @@ class StartNodeTest(unittest.TestCase):
         self.assertIn("bzrk timed out after 120s", text)
 
 
+class CheckLogSpikeNodeTest(unittest.TestCase):
+    def setUp(self):
+        inv.configure(
+            bzrk_search=self._search, since_hours=lambda s: 1.0,
+            q_errors="Q_ERRORS", q_soc_log_spike="Q_SPIKE", q_trace_find_errors="Q_TRACE",
+        )
+        self.responses = {}
+
+    def _search(self, kql, since):
+        return self.responses[kql]
+
+    def _spike_response(self, service, hits):
+        return bzrk_json_table(["service", "hits"], [[service, hits]]), False
+
+    def test_no_service_param_is_a_validation_error(self):
+        text, is_error, next_node = inv.run_error_rate_node("check_log_spike", "1h ago", None)
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("service", text.lower())
+
+    def test_spike_advances_to_check_traces(self):
+        # 55 baseline buckets averaging ~2, last 5 buckets averaging 20 --
+        # 20 > 2 * SPIKE_MULTIPLIER (3), so this is a spike.
+        hits = [2] * 55 + [20] * 5
+        self.responses["Q_SPIKE"] = self._spike_response("checkout", hits)
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_log_spike", "1h ago", "checkout")
+        self.assertFalse(is_error)
+        self.assertEqual(next_node, "check_traces")
+        self.assertIn("check_traces", text)
+        self.assertIn("service=\"checkout\"", text)
+
+    def test_no_spike_concludes_with_manual_review_recommendation(self):
+        hits = [2] * 60  # flat, no spike
+        self.responses["Q_SPIKE"] = self._spike_response("checkout", hits)
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_log_spike", "1h ago", "checkout")
+        self.assertFalse(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("manual review", text.lower())
+
+    def test_service_not_present_in_series_halts(self):
+        self.responses["Q_SPIKE"] = self._spike_response("auth", [1] * 60)
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_log_spike", "1h ago", "checkout")
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("no log-volume data", text.lower())
+
+    def test_insufficient_buckets_halts(self):
+        self.responses["Q_SPIKE"] = self._spike_response("checkout", [1, 2, 3])
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_log_spike", "1h ago", "checkout")
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("insufficient", text.lower())
+
+    def test_backend_failure_halts(self):
+        self.responses["Q_SPIKE"] = ("bzrk timed out", True)
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_log_spike", "1h ago", "checkout")
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("FAILED", text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_investigation.py
+++ b/tests/test_investigation.py
@@ -184,5 +184,56 @@ class CheckLogSpikeNodeTest(unittest.TestCase):
         self.assertIn("FAILED", text)
 
 
+class CheckTracesNodeTest(unittest.TestCase):
+    def setUp(self):
+        inv.configure(
+            bzrk_search=self._search, since_hours=lambda s: 1.0,
+            q_errors="Q_ERRORS", q_soc_log_spike="Q_SPIKE", q_trace_find_errors="Q_TRACE",
+        )
+        self.responses = {}
+
+    def _search(self, kql, since):
+        return self.responses[kql]
+
+    def test_no_service_param_is_a_validation_error(self):
+        text, is_error, next_node = inv.run_error_rate_node("check_traces", "1h ago", None)
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+
+    def test_failing_traces_found_concludes_with_root_cause_verdict(self):
+        rows = [
+            ["t1", "POST /checkout", "2026-08-28T00:00:00Z", "checkout"],
+            ["t2", "GET /cart", "2026-08-28T00:01:00Z", "checkout"],
+            ["t3", "POST /pay", "2026-08-28T00:02:00Z", "auth"],
+        ]
+        self.responses["Q_TRACE"] = bzrk_json_table(
+            ["trace_id", "span_name", "timestamp", "service"], rows), False
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_traces", "1h ago", "checkout")
+        self.assertFalse(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("2 failing", text)
+        self.assertIn("checkout", text)
+        self.assertNotIn("auth", text)  # filtered to the offending service
+
+    def test_no_matching_traces_concludes_with_ingestion_gap_hypothesis(self):
+        rows = [["t1", "GET /health", "2026-08-28T00:00:00Z", "other-service"]]
+        self.responses["Q_TRACE"] = bzrk_json_table(
+            ["trace_id", "span_name", "timestamp", "service"], rows), False
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_traces", "1h ago", "checkout")
+        self.assertFalse(is_error)
+        self.assertIsNone(next_node)
+        self.assertIn("no failing traces", text.lower())
+        self.assertIn("ingestion lag", text.lower())
+
+    def test_backend_failure_halts(self):
+        self.responses["Q_TRACE"] = ("bzrk timed out", True)
+        text, is_error, next_node = inv.run_error_rate_node(
+            "check_traces", "1h ago", "checkout")
+        self.assertTrue(is_error)
+        self.assertIsNone(next_node)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tool_discovery.py
+++ b/tests/test_tool_discovery.py
@@ -118,6 +118,7 @@ PHRASINGS = {
     "trace_find_errors": ["find traces with errors", "which requests failed", "show me error traces"],
     "trace_analyze": ["analyze this specific trace", "break down a trace by id", "inspect one trace"],
     "sre_error_rate": ["what is the error rate", "error rate trend", "show error rate over time"],
+    "investigate_error_rate": ["investigate why error rate is elevated", "troubleshoot high error rate", "step-by-step error investigation"],
     "forecast_capacity": ["forecast when we run out of capacity", "predict disk usage trend", "capacity forecast"],
     "sre_host_headroom": ["how much headroom does a host have", "host capacity remaining", "spare host capacity"],
     "sre_ingest_health": ["is ingestion healthy", "check ingest pipeline health", "ingestion lag status"],


### PR DESCRIPTION
## Summary

Implements `investigate_error_rate`, a fixed decision-tree MCP tool addressing issue #24 ("composition ceiling" — the dev brief's own named weakness: fixed tools can't compose across signals, and Datadog's answer is agent-authored `execute_code`, which this project's constraints deliberately rule out).

**Design → spec → plan → implementation, each step reviewed and merged separately:**
- Design brainstormed and approved in chat (#68 — spec)
- Turned into a bite-sized TDD plan, every code block hand-verified before merging (#69 — plan)
- Implemented via subagent-driven development: fresh implementer per task, task-scoped review after each, final whole-branch review at the end

**What it does:** composes three existing SRE signals into one investigation — `errors_by_service` → (if elevated) `soc_log_spike` → (if correlated) `trace_find_errors` — one hop per call, no agent-authored composition, same reproducibility posture as every other fixed tool in this project.

**Key design decisions** (full rationale in `docs/investigation-decision-tree-implementation-spec.md`):
- v1 scope is SRE fault-isolation only. The adversarial challenge from #24 ("does a tree solve composition or relocate it onto whoever maintains it?") resolves differently per domain — SRE's branching logic is already written down as prose in `primers/sre.md`'s escalation thresholds, so encoding it is promotion, not relocation.
- Each hop executes itself against the underlying tools' pre-formatting JSON data path — never parses another tool's display text.
- Step-by-step, not one-shot: a wrong branch at hop 1 in a one-shot walk would commit silently to a bad verdict with no checkpoint — the same silent-failure risk issue #12 (wrong-answer containment) already treats as this project's one hard reliability gate.
- No server-side session state — `node`/`service`/`since` parameters carry everything between calls.

**Process notes worth surfacing:**
- One real bug was caught before it ever shipped: `bzrk`'s `--json` mode returns the plain-text `"(no rows)"` sentinel for an empty result, not an empty JSON array — an earlier draft misreported that as a parse failure and halted every empty-result investigation. Caught by hand-running the plan's code in a scratch environment before finalizing the plan (#69), with its own regression test.
- The final whole-branch review found one Important, consistency-only finding (missing `service` parameter validation vs. the `detect_anomalies` pattern) — fixed and re-reviewed clean. Two Minor findings were reviewed and judged intentional/acceptable as designed, and parked rather than changed.
- **Version bump deliberately deferred**, per this project's established convention of bumping `__version__` and adding release notes as its own dedicated step, not silently inside a feature PR.

## Test plan
- [x] `python3 -m unittest discover -s tests` — 906 tests, 1 skip, all pass
- [x] `python3 evals/mcp_protocol_smoke.py --include-http` — all checks pass (confirms the new tool registers correctly in `tools/list` on both stdio and HTTP transports)
- [x] Every task individually reviewed for spec compliance + code quality (6 task reviews, all clean)
- [x] Final whole-branch review (1 Important finding, fixed + re-reviewed clean; 2 Minor findings parked with rulings)
- [x] Eval case added (`evals/router_cases.jsonl`); sanity-checked against the mock backend (no live model credentials available in this environment — live-model accuracy check is a follow-up, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)