### PR TITLE
docs: v1.27.0 — version-bump catch-up for security fixes and investigate_error_rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,17 @@ LLM answer [Berserk](https://bzrk.dev) observability questions. The LLM
 
 ## Release history
 
-Current version: **1.26.0**. This is a bullet-point overview, most recent
+Current version: **1.27.0**. This is a bullet-point overview, most recent
 first — full detail for each notable release lives in
 [`docs/releases/`](docs/releases/).
 
+- **v1.27.0** (2026-08-28) — Five security findings from an independent
+  Codex review (KQL validator bypasses, unfenced telemetry attributes, an
+  injection-delimiter gap, an OAuth-header redirect leak, and a
+  string-truthiness authorization bug), and `investigate_error_rate`
+  (issue #24): a fixed, step-by-step decision-tree investigation tool for
+  elevated error rate, scoped to SRE/Ops. See
+  [details](docs/releases/v1.27.0.md).
 - **v1.26.0** (2026-08-24) — Untrusted-data fencing, tool tiers, just-in-time
   tool discovery (`find_tool`, 92% measured token reduction), a live
   quota-window check (`claude_quota_status`), an `agent` parameter on the base

--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -82,7 +82,7 @@ import schema_registry
 import secret_scan
 import tool_discovery
 
-__version__ = "1.26.0"
+__version__ = "1.27.0"
 
 
 def log(msg):

--- a/docs/releases/v1.27.0.md
+++ b/docs/releases/v1.27.0.md
@@ -1,0 +1,82 @@
+# v1.27.0 — Security remediation and the investigation decision tree
+
+Released: 2026-08-28
+
+Two independent pieces of work, shipped as separate PRs without a version
+bump at the time, caught up here: five real security findings from an
+independent Codex review, and the first fixed decision-tree investigation
+tool.
+
+## Security fixes
+
+Codex ran a security review of the codebase and found five issues, each
+refined over multiple rounds of re-review (independently reproduced before
+fixing, then re-verified against the final code):
+
+- **SEC-01** — `kql_validation.py`'s source-introducing-operator check let
+  `join` through as a warning instead of a hard block, and had no check at
+  all for `cluster()`/`database()`/`table()`/`toscalar()`/`lookup` or the
+  `in (...)`/`!in (...)`/`in~ (...)` tabular-subquery form, including
+  disguised variants (bracket-quoted names, function-backed sources, `union`
+  as the first token). Replaced the narrow blacklist with a structural
+  check: any `|` character anywhere inside an `in(...)` group, at any paren
+  depth, is treated as proof of a tabular subquery — a scalar literal list
+  never contains one.
+- **SEC-02** — session ID, model name, and tool name (attacker-controlled
+  telemetry attributes) reached the model unfenced in six
+  `agent_analytics.py` report functions. Wrapped with the existing
+  fence-and-redact primitive already used elsewhere in the same file.
+- **SEC-03** — `parser_factory.py`'s untrusted-sample-data prompt delimiter
+  didn't neutralize a forged closing tag using the HTML5 named entity
+  `&sol;` (or double-encoded `&amp;sol;`) for "/" — only numeric/hex forms
+  were covered. Fixed in both `parser_factory.py` and the pre-existing,
+  equally-affected pattern in `berserk_mcp.py`.
+- **SEC-04** — `quota_status.py`'s live-usage fetch used plain
+  `urllib.request.urlopen`, which follows redirects and re-sends the OAuth
+  `Authorization` header to the redirect target. Switched to the shared
+  no-redirect opener — including the production `claude_quota_status`
+  tool's own separate default that had shadowed the first fix.
+- **SEC-05** — `berserk_mcp.py`'s CanonLoom dispatch coerced
+  `auto_promote`/`include_staging` with `bool(...)`, which turns the string
+  `"false"` into Python `True`. Switched to strict `is True` checks for
+  those default-off authorization gates, and `is not False` for
+  `record_telemetry` (a default-on audit control, where the same fix would
+  have silently disabled logging on a malformed value instead of failing
+  safe).
+
+Every fix and every re-review finding has dedicated regression coverage,
+confirmed failing before the fix and passing after.
+
+## `investigate_error_rate` (issue #24)
+
+A fixed, step-by-step decision-tree investigation tool answering the dev
+brief's "composition ceiling" concern — fixed tools can't compose across
+signals the way ad hoc code execution can — without adding code execution.
+Scoped to SRE/Ops for v1; the general mechanism and a generic dispatcher
+variant are documented as considered-but-not-built in
+[`docs/investigation-decision-tree-implementation-spec.md`](../investigation-decision-tree-implementation-spec.md).
+
+- **Self-executing hops, not agent-mediated.** The model calls
+  `investigate_error_rate(since="1h ago", node="start")` one hop at a time —
+  `start` → `check_log_spike` → `check_traces` — rather than the tool
+  running the whole tree in one shot. This was the deciding design choice,
+  not a convenience: it contains a wrong answer to one hop instead of
+  letting it propagate through a silent multi-step run (issue #12).
+- Backend failures halt explicitly rather than letting the investigation
+  silently proceed on missing data.
+- All service-name input goes through the same interpolation validator
+  already used by `detect_anomalies`, and the full response is fenced as
+  untrusted data before reaching the model (issue #11's convention).
+
+This also closes the loop on the dev brief's other named gap — "we return
+raw log lines to the model unfenced" — which was already fixed by issue #11
+before this brief was written; see the correction appended to
+[`docs/berserk-dev-brief-2026-08-20.md`](../berserk-dev-brief-2026-08-20.md).
+
+## Also in this release
+
+- A CI eval-gate regression (the mock router had no route for the new
+  `investigate_error_rate` eval case) and a packaging gap (`investigation.py`
+  was missing from `pyproject.toml`'s module list, so a real `pip install`
+  shipped a server that couldn't import it) — both caught by CI, not local
+  testing, and fixed before merge.


### PR DESCRIPTION
## Summary
- Both #66 (SEC-01–SEC-05 security fixes) and #70 (`investigate_error_rate`, issue #24) shipped real functional changes without a version bump — this project's convention treats that as its own dedicated step, not silent inside a feature PR.
- Bumps `__version__` to 1.27.0, adds the README release-history bullet, and adds `docs/releases/v1.27.0.md` covering both pieces of work.
- Docs-only change: no code paths touched.

## Test plan
- [x] `python3 -m unittest discover -s tests` — 906 tests, OK (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)