### PR TITLE
ci: hourly workflow to trigger CodeRabbit review on open PRs

### DIFF
--- a/.github/workflows/coderabbit-review-trigger.yml
+++ b/.github/workflows/coderabbit-review-trigger.yml
@@ -1,0 +1,64 @@
+name: Trigger CodeRabbit review
+
+# This repo's CodeRabbit plan does not auto-review PRs (GitHub gates
+# automatic review behind a 10-star minimum, and this repo has fewer).
+# CodeRabbit still reviews on request -- commenting "@coderabbitai review"
+# on a PR works regardless of star count. This workflow does that on a
+# schedule so open PRs get reviewed without a human remembering to ask.
+#
+# The account's plan allows 1 included review per hour, so this workflow
+# triggers at most one PR per run and skips any PR CodeRabbit has already
+# reviewed at its current head commit, so a quiet repo doesn't waste the
+# hourly allowance re-triggering an unchanged PR.
+
+on:
+  schedule:
+    - cron: "0 * * * *"  # hourly, matching the plan's 1-review/hour cap
+  workflow_dispatch: {}   # manual run button, for testing or an on-demand nudge
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment @coderabbitai review on the oldest un-reviewed open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Non-draft PRs targeting main, oldest-updated first -- matches
+          # .coderabbit.yaml's own auto_review scope, and means no PR
+          # starves behind a busier one.
+          prs=$(gh pr list --repo "$REPO" --state open --base main \
+                --json number,isDraft,updatedAt,headRefOid \
+                --jq '[.[] | select(.isDraft == false)] | sort_by(.updatedAt)')
+
+          # Process substitution, not a pipe -- a piped `while read` runs in
+          # a subshell in bash, so `exit` inside it would only end the
+          # subshell and fall through to the "nothing to do" message below
+          # even after a successful trigger. This form keeps the loop in
+          # the current shell.
+          while read -r pr_json; do
+            pr=$(jq -r '.number' <<<"$pr_json")
+            head_sha=$(jq -r '.headRefOid' <<<"$pr_json")
+
+            last_reviewed_sha=$(gh api "repos/$REPO/pulls/$pr/reviews" \
+              --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last | .commit_id // ""')
+
+            if [ "$last_reviewed_sha" = "$head_sha" ]; then
+              echo "PR #$pr: already reviewed at $head_sha, skipping"
+              continue
+            fi
+
+            echo "PR #$pr: triggering review at $head_sha"
+            gh pr comment "$pr" --repo "$REPO" --body "@coderabbitai review"
+            exit 0  # one trigger per run -- matches the account's hourly cap
+          done < <(echo "$prs" | jq -c '.[]')
+
+          echo "No open, non-draft PR against main needs a review right now."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,21 @@ the [`bzrk`](https://docs.bzrk.dev) CLI and log in to a profile — see the
 ## Tests
 
 Every PR runs the full suite on Linux + Windows × Python 3.9 / 3.11 / 3.12. Any
-non-draft PR targeting `main` also gets an automatic CodeRabbit review (config:
+non-draft PR targeting `main` also gets a CodeRabbit review (config:
 `.coderabbit.yaml`), and security-sensitive changes get a manual Codex review
-pass. Locally:
+pass.
+
+CodeRabbit's own automatic-review trigger needs 10+ GitHub stars on the repo,
+which this project doesn't have yet — reviews still happen, just via an
+explicit `@coderabbitai review` comment. A scheduled workflow
+(`.github/workflows/coderabbit-review-trigger.yml`, hourly, matching the
+account's 1-review/hour plan cap) posts that comment on the oldest open PR
+that hasn't been reviewed at its current commit yet, so this doesn't depend
+on a human remembering to ask. Once the repo passes the star threshold,
+CodeRabbit's own automatic review takes over and this workflow becomes a
+no-op (it always checks for an unreviewed commit first).
+
+Locally:
 
 ```bash
 python tests/test_berserk_mcp.py     # fast focused run, must stay green


### PR DESCRIPTION
## Summary
- CodeRabbit's automatic-review trigger needs 10+ GitHub stars; this repo has fewer, confirmed empirically against PR #79/#80/#81 (none got an automatic review despite a correctly-configured `.coderabbit.yaml`).
- Adds an hourly workflow that posts `@coderabbitai review` on the oldest open, non-draft PR against `main` that hasn't been reviewed at its current commit — works around the star gate without a human remembering to ask.
- Confirmed the plan's rate limit empirically too (a second manual trigger came back "Review rate limited"), so the workflow fires at most once per run and skips already-reviewed PRs.
- Real bug caught during end-to-end rehearsal against the live repo before shipping: a piped `while read` ran in a subshell, so `exit 0` didn't actually stop the script early. Fixed with process substitution.
- Updates CONTRIBUTING.md to explain why this exists and that it becomes a no-op once the repo passes the star threshold.

## Test plan
- [x] `python3 -m unittest discover -s tests` — 914 tests, OK
- [x] Workflow YAML parses; shell script syntax validated (`bash -n`)
- [x] Full listing/dedup logic dry-run against the real repo's live PR state, both before and after the exit-behavior fix
- [x] Live end-to-end run confirmed: found PR #81 needed a review, posted the trigger comment successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)