### PR TITLE
fix: correctly derive Hermes /models discovery URL for real providers

### DIFF
--- a/berserk_mcp.py
+++ b/berserk_mcp.py
@@ -4744,10 +4744,10 @@ def _doctor_check_llm_reachability():
         url_note = f" (using the unconfigured default {url!r})"
     else:
         url_note = ""
-    models_url = url.rsplit("/", 3)[0] + "/api/models" if "/api/" in url else None
+    models_url = parser_factory.hermes_models_url(url)
     if not models_url:
         return _doctor_result(
-            "llm_hermes_reachability", "fail", f"cannot derive /api/models from {url!r}",
+            "llm_hermes_reachability", "fail", f"cannot derive a /models endpoint from {url!r}",
             remediation="confirm BERSERK_LLM_HERMES_URL points at a chat/completions endpoint",
             required=False,
         )

--- a/parser_factory.py
+++ b/parser_factory.py
@@ -404,6 +404,26 @@ def _reset_hermes_model_cache():
     _hermes_model_cache.clear()
 
 
+def hermes_models_url(url):
+    """Derive the OpenAI-compatible /models discovery endpoint from a
+    configured chat-completions URL. Suffix-based, not positional: strips
+    a trailing '/chat/completions' and appends '/models'. A purely
+    positional derivation (rsplit('/', 3)[0]) happened to work for the
+    hardcoded localhost default (http://localhost:3000/api/chat/completions
+    -> .../api/models) but produced a doubled, wrong URL for a real
+    provider with a different path depth -- confirmed live 2026-08-29:
+    https://openrouter.ai/api/v1/chat/completions derived to
+    https://openrouter.ai/api/api/models (HTTP 404) instead of the real
+    https://openrouter.ai/api/v1/models. Suffix-stripping is depth-agnostic
+    and gets both right. Returns None if the URL doesn't end with the
+    expected suffix, matching the original behavior for a URL shape this
+    can't handle."""
+    suffix = "/chat/completions"
+    if not url.endswith(suffix):
+        return None
+    return url[: -len(suffix)] + "/models"
+
+
 def _hermes_model():
     configured = os.environ.get("BERSERK_LLM_HERMES_MODEL")
     if configured:
@@ -412,9 +432,9 @@ def _hermes_model():
     cached = _hermes_model_cache.get(url)
     if cached is not None and cached[1] > time.monotonic():
         return cached[0], None
-    models_url = url.rsplit("/", 3)[0] + "/api/models" if "/api/" in url else None
+    models_url = hermes_models_url(url)
     if not models_url:
-        return None, "hermes: cannot derive /api/models from configured URL"
+        return None, "hermes: cannot derive a /models endpoint from configured URL (expected it to end with /chat/completions)"
     key = os.environ.get("HERMES_API_KEY", "")
     headers = {"Authorization": f"Bearer {key}"} if key else {}
     out, err = _http_get_json(models_url, headers)

--- a/tests/test_berserk_mcp.py
+++ b/tests/test_berserk_mcp.py
@@ -4498,6 +4498,38 @@ class DoctorPreflightTest(unittest.TestCase):
             if orig_env is not None:
                 os.environ["BERSERK_LLM_HERMES_URL"] = orig_env
 
+    def test_llm_reachability_probes_the_correct_url_for_a_real_provider(self):
+        # Real bug found live, 2026-08-29: _doctor_check_llm_reachability
+        # derived /api/models positionally (rsplit('/', 3)[0]), which
+        # happened to work for the hardcoded localhost default but produced
+        # a doubled, wrong URL for a provider at a different path depth --
+        # https://openrouter.ai/api/v1/chat/completions derived to
+        # https://openrouter.ai/api/api/models (real HTTP 404 against the
+        # live API). Now routed through the shared, suffix-based
+        # parser_factory.hermes_models_url(), fixed for both. This test
+        # locks the actual URL probed, not just pass/fail.
+        import _http
+        orig_get = _http.http_get_json
+        orig_env = os.environ.pop("BERSERK_LLM_HERMES_URL", None)
+        os.environ["BERSERK_LLM_HERMES_URL"] = "https://openrouter.ai/api/v1/chat/completions"
+        probed = {}
+
+        def fake_get(url, headers, timeout=120):
+            probed["url"] = url
+            return {"data": []}, None
+
+        _http.http_get_json = fake_get
+        try:
+            result = bm._doctor_check_llm_reachability()
+            self.assertEqual(probed["url"], "https://openrouter.ai/api/v1/models")
+            self.assertEqual(result["status"], "pass")
+        finally:
+            _http.http_get_json = orig_get
+            if orig_env is not None:
+                os.environ["BERSERK_LLM_HERMES_URL"] = orig_env
+            else:
+                os.environ.pop("BERSERK_LLM_HERMES_URL", None)
+
     def test_canonloom_reachability_skip_when_unconfigured(self):
         orig = os.environ.pop("CANONLOOM_SERVER_URL", None)
         try:

--- a/tests/test_parser_factory.py
+++ b/tests/test_parser_factory.py
@@ -392,6 +392,38 @@ class LlmClientTest(ParserFactoryTestBase):
         self.assertEqual(len(self._llm_get_calls), 2)
 
 
+class HermesModelsUrlTest(unittest.TestCase):
+    """Pure function, no fixtures needed. Real bug found live, 2026-08-29:
+    the old positional derivation (rsplit('/', 3)[0] + '/api/models')
+    happened to work for the hardcoded localhost default but produced a
+    doubled, wrong URL for a real provider at a different path depth."""
+
+    def test_localhost_default_shape_unchanged(self):
+        self.assertEqual(
+            pf.hermes_models_url("http://localhost:3000/api/chat/completions"),
+            "http://localhost:3000/api/models",
+        )
+
+    def test_openrouter_shape_now_correct(self):
+        # Confirmed live: the old derivation produced
+        # https://openrouter.ai/api/api/models (HTTP 404). The real
+        # endpoint is https://openrouter.ai/api/v1/models.
+        self.assertEqual(
+            pf.hermes_models_url("https://openrouter.ai/api/v1/chat/completions"),
+            "https://openrouter.ai/api/v1/models",
+        )
+
+    def test_url_not_ending_in_chat_completions_returns_none(self):
+        self.assertIsNone(pf.hermes_models_url("https://example.com/v1/completions"))
+
+    def test_url_with_trailing_slash_returns_none(self):
+        # Deliberately strict rather than guessing at a normalized form --
+        # an unexpected shape should fail loudly (None -> a clear error
+        # upstream), not silently produce a wrong URL.
+        self.assertIsNone(
+            pf.hermes_models_url("https://example.com/v1/chat/completions/"))
+
+
 # ---------- P2: source profiling and schema knowledge store ----------
 class SourceProfileTest(ParserFactoryTestBase):
     def test_fieldstats_resource_paths_are_normalized(self):


### PR DESCRIPTION
## Summary
- Real bug found live while setting up an OpenRouter provider for berserk-mcp's own parser-factory generation features: `/models` discovery URL was derived positionally, which only worked for the hardcoded `localhost:3000` default. Against OpenRouter's real endpoint it produced a doubled, wrong URL (`.../api/api/models`, confirmed HTTP 404 live).
- `self_check`/`--doctor` reported the provider as unreachable even though it was fully working — verified separately with a real `llm_complete("hermes", ...)` call.
- Duplicated in two places, both wrong the same way. Extracted a shared, suffix-based helper (`parser_factory.hermes_models_url()`) that's depth-agnostic instead of positional.

## Test plan
- [x] 4 new unit tests for `hermes_models_url()` directly
- [x] 1 new integration test locking the actual probed URL
- [x] Full suite: 919 tests (up from 914), OK
- [x] Verified live against the real OpenRouter API — `_doctor_check_llm_reachability()` now reports `status=pass` at the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)